### PR TITLE
Feature: Add a hintrunner for the Vm

### DIFF
--- a/pkg/hintrunner/error.go
+++ b/pkg/hintrunner/error.go
@@ -37,6 +37,7 @@ func (e *HintError) Unwrap() error {
 	return e.err
 }
 
+// OperandError is returned when the error is detected during an operand get/resolve execution
 type OperandError struct {
 	operandName string
 	err         error

--- a/pkg/hintrunner/error.go
+++ b/pkg/hintrunner/error.go
@@ -1,0 +1,40 @@
+package hintrunner
+
+import "fmt"
+
+// HintRunnerError represents error ocurring during the hint runner
+type HintRunnerError struct {
+	err error
+}
+
+func NewHintRunnerError(err error) *HintRunnerError {
+	return &HintRunnerError{err}
+}
+
+func (e *HintRunnerError) Error() string {
+	return fmt.Sprintf("error in hint runner: %s", e.err.Error())
+}
+
+func (e *HintRunnerError) Unwrap() error {
+	return e.err
+}
+
+// HintError stores information about the hint being executed as well as its cause
+type HintError struct {
+	hintName string
+	err      error
+}
+
+func NewHintError(hintName string, err error) *HintError {
+	return &HintError{hintName, err}
+}
+
+func (e *HintError) Error() string {
+	return fmt.Sprintf("error executing hint %s: %s", e.hintName, e.err.Error())
+}
+
+func (e *HintError) Unwrap() error {
+	return e.err
+}
+
+// todo(rodro): Should add custom error for operand?

--- a/pkg/hintrunner/error.go
+++ b/pkg/hintrunner/error.go
@@ -37,4 +37,19 @@ func (e *HintError) Unwrap() error {
 	return e.err
 }
 
-// todo(rodro): Should add custom error for operand?
+type OperandError struct {
+	operandName string
+	err         error
+}
+
+func NewOperandError(operandName string, err error) *OperandError {
+	return &OperandError{operandName, err}
+}
+
+func (e *OperandError) Error() string {
+	return fmt.Sprintf("failed to get/resolve operand %s: %s", e.operandName, e.err.Error())
+}
+
+func (e *OperandError) Unwrap() error {
+	return e.err
+}

--- a/pkg/hintrunner/hint.go
+++ b/pkg/hintrunner/hint.go
@@ -1,0 +1,31 @@
+package hintrunner
+
+import (
+	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
+	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
+)
+
+type Hinter interface {
+	Execute(vm *VM.VirtualMachine) *HintError
+}
+
+type AllocSegment struct {
+	dst CellRefer
+}
+
+func (h AllocSegment) Execute(vm *VM.VirtualMachine) *HintError {
+	segmentIndex := vm.MemoryManager.Memory.AllocateEmptySegment()
+	memAddress := memory.MemoryValueFromSegmentAndOffset(segmentIndex, 0)
+
+	cell, err := h.dst.Get(vm)
+	if err != nil {
+		return NewHintError("AllocSegment", err)
+	}
+
+	err = cell.Write(memAddress)
+	if err != nil {
+		return NewHintError("AllocSegment", err)
+	}
+
+	return nil
+}

--- a/pkg/hintrunner/hint.go
+++ b/pkg/hintrunner/hint.go
@@ -3,11 +3,14 @@ package hintrunner
 import (
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
 	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
+	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
 type Hinter interface {
 	Execute(vm *VM.VirtualMachine) *HintError
 }
+
+const allocSegmentName = "AllocSegment"
 
 type AllocSegment struct {
 	dst CellRefer
@@ -19,12 +22,59 @@ func (hint AllocSegment) Execute(vm *VM.VirtualMachine) *HintError {
 
 	cell, err := hint.dst.Get(vm)
 	if err != nil {
-		return NewHintError("AllocSegment", err)
+		return NewHintError(allocSegmentName, err)
 	}
 
 	err = cell.Write(memAddress)
 	if err != nil {
-		return NewHintError("AllocSegment", err)
+		return NewHintError(allocSegmentName, err)
+	}
+
+	return nil
+}
+
+const testLessThanName = "TestLessThan"
+
+type TestLessThan struct {
+	dst CellRefer
+	lhs ResOperander
+	rhs ResOperander
+}
+
+func (hint TestLessThan) Execute(vm *VM.VirtualMachine) *HintError {
+	lhsVal, err := hint.lhs.Resolve(vm)
+	if err != nil {
+		return NewHintError(testLessThanName, err)
+	}
+
+	rhsVal, err := hint.rhs.Resolve(vm)
+	if err != nil {
+		return NewHintError(testLessThanName, err)
+	}
+
+	lhsFelt, err := lhsVal.ToFieldElement()
+	if err != nil {
+		return NewHintError(testLessThanName, err)
+	}
+
+	rhsFelt, err := rhsVal.ToFieldElement()
+	if err != nil {
+		return NewHintError(testLessThanName, err)
+	}
+
+	resFelt := f.Element{}
+	if lhsFelt.Cmp(rhsFelt) <= 0 {
+		resFelt.SetOne()
+	}
+
+	dstCell, err := hint.dst.Get(vm)
+	if err != nil {
+		return NewHintError(testLessThanName, err)
+	}
+
+	err = dstCell.Write(memory.MemoryValueFromFieldElement(&resFelt))
+	if err != nil {
+		return NewHintError(testLessThanName, err)
 	}
 
 	return nil

--- a/pkg/hintrunner/hint.go
+++ b/pkg/hintrunner/hint.go
@@ -13,11 +13,11 @@ type AllocSegment struct {
 	dst CellRefer
 }
 
-func (h AllocSegment) Execute(vm *VM.VirtualMachine) *HintError {
+func (hint AllocSegment) Execute(vm *VM.VirtualMachine) *HintError {
 	segmentIndex := vm.MemoryManager.Memory.AllocateEmptySegment()
 	memAddress := memory.MemoryValueFromSegmentAndOffset(segmentIndex, 0)
 
-	cell, err := h.dst.Get(vm)
+	cell, err := hint.dst.Get(vm)
 	if err != nil {
 		return NewHintError("AllocSegment", err)
 	}

--- a/pkg/hintrunner/hint_test.go
+++ b/pkg/hintrunner/hint_test.go
@@ -1,1 +1,42 @@
 package hintrunner
+
+import (
+	"testing"
+
+	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
+	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllocSegment(t *testing.T) {
+	vm := defaultVirtualMachine()
+
+	vm.Context.Ap = 3
+	vm.Context.Fp = 0
+
+	var ap ApCellRef = 5
+	var fp FpCellRef = 9
+
+	alloc1 := AllocSegment{ap}
+	alloc2 := AllocSegment{fp}
+
+	err := alloc1.Execute(vm)
+	t.Log(err)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(vm.MemoryManager.Memory.Segments))
+	require.Equal(
+		t,
+		memory.MemoryValueFromSegmentAndOffset(2, 0),
+		readFrom(vm, VM.ExecutionSegment, vm.Context.Ap+5),
+	)
+
+	err = alloc2.Execute(vm)
+	require.Nil(t, err)
+	require.Equal(t, 4, len(vm.MemoryManager.Memory.Segments))
+	require.Equal(
+		t,
+		memory.MemoryValueFromSegmentAndOffset(3, 0),
+		readFrom(vm, VM.ExecutionSegment, vm.Context.Fp+9),
+	)
+
+}

--- a/pkg/hintrunner/hint_test.go
+++ b/pkg/hintrunner/hint_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestAllocSegment(t *testing.T) {
 	vm := defaultVirtualMachine()
-
 	vm.Context.Ap = 3
 	vm.Context.Fp = 0
 

--- a/pkg/hintrunner/hint_test.go
+++ b/pkg/hintrunner/hint_test.go
@@ -1,6 +1,7 @@
 package hintrunner
 
 import (
+	"math/big"
 	"testing"
 
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
@@ -38,4 +39,60 @@ func TestAllocSegment(t *testing.T) {
 		readFrom(vm, VM.ExecutionSegment, vm.Context.Fp+9),
 	)
 
+}
+
+func TestTestLessThanFalse(t *testing.T) {
+	vm := defaultVirtualMachine()
+	vm.Context.Ap = 0
+	vm.Context.Fp = 0
+	writeTo(vm, VM.ExecutionSegment, 0, memory.MemoryValueFromInt(17))
+
+	var dst ApCellRef = 1
+
+	lhs := Immediate(*big.NewInt(32))
+
+	var rhsRef FpCellRef = 0
+	rhs := Deref{rhsRef}
+
+	hint := TestLessThan{
+		dst: dst,
+		lhs: lhs,
+		rhs: rhs,
+	}
+
+	err := hint.Execute(vm)
+	require.Nil(t, err)
+	require.Equal(
+		t,
+		memory.EmptyMemoryValueAsFelt(),
+		readFrom(vm, VM.ExecutionSegment, 1),
+	)
+}
+
+func TestTestLessThanTrue(t *testing.T) {
+	vm := defaultVirtualMachine()
+	vm.Context.Ap = 0
+	vm.Context.Fp = 0
+	writeTo(vm, VM.ExecutionSegment, 0, memory.MemoryValueFromInt(23))
+
+	var dst ApCellRef = 1
+
+	lhs := Immediate(*big.NewInt(13))
+
+	var rhsRef FpCellRef = 0
+	rhs := Deref{rhsRef}
+
+	hint := TestLessThan{
+		dst: dst,
+		lhs: lhs,
+		rhs: rhs,
+	}
+
+	err := hint.Execute(vm)
+	require.Nil(t, err)
+	require.Equal(
+		t,
+		memory.MemoryValueFromInt(1),
+		readFrom(vm, VM.ExecutionSegment, 1),
+	)
 }

--- a/pkg/hintrunner/hint_test.go
+++ b/pkg/hintrunner/hint_test.go
@@ -1,0 +1,1 @@
+package hintrunner

--- a/pkg/hintrunner/hintrunner.go
+++ b/pkg/hintrunner/hintrunner.go
@@ -10,8 +10,8 @@ type HintRunner struct {
 	hints map[uint64]Hinter
 }
 
-func CreateHintRunner() *HintRunner {
-	return nil
+func CreateHintRunner(hints map[uint64]Hinter) HintRunner {
+	return HintRunner{hints}
 }
 
 func (hr HintRunner) RunHint(vm *VM.VirtualMachine) *HintRunnerError {

--- a/pkg/hintrunner/hintrunner.go
+++ b/pkg/hintrunner/hintrunner.go
@@ -2,7 +2,6 @@ package hintrunner
 
 import (
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
-	"golang.org/x/exp/constraints"
 )
 
 // todo: Can two or more hints be assigned to a specific PC?
@@ -26,12 +25,4 @@ func (hr HintRunner) RunHint(vm *VM.VirtualMachine) *HintRunnerError {
 		return NewHintRunnerError(err)
 	}
 	return nil
-}
-
-// move this function to a possible util packages
-func Abs[T constraints.Signed](num T) T {
-	if num >= 0 {
-		return num
-	}
-	return num * -1
 }

--- a/pkg/hintrunner/hintrunner.go
+++ b/pkg/hintrunner/hintrunner.go
@@ -1,0 +1,37 @@
+package hintrunner
+
+import (
+	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
+	"golang.org/x/exp/constraints"
+)
+
+// todo: Can two or more hints be assigned to a specific PC?
+type HintRunner struct {
+	// A mapping from program counter to hint implementation
+	hints map[uint64]Hinter
+}
+
+func CreateHintRunner() *HintRunner {
+	return nil
+}
+
+func (hr HintRunner) RunHint(vm *VM.VirtualMachine) *HintRunnerError {
+	hint := hr.hints[vm.Context.Pc]
+	if hint == nil {
+		return nil
+	}
+
+	err := hint.Execute(vm)
+	if err != nil {
+		return NewHintRunnerError(err)
+	}
+	return nil
+}
+
+// move this function to a possible util packages
+func Abs[T constraints.Signed](num T) T {
+	if num >= 0 {
+		return num
+	}
+	return num * -1
+}

--- a/pkg/hintrunner/hintrunner_test.go
+++ b/pkg/hintrunner/hintrunner_test.go
@@ -1,0 +1,47 @@
+package hintrunner
+
+import (
+	"testing"
+
+	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
+	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExistingHint(t *testing.T) {
+	vm := defaultVirtualMachine()
+	vm.Context.Ap = 3
+
+	var ap ApCellRef = 5
+	allocHint := AllocSegment{ap}
+
+	hr := CreateHintRunner(map[uint64]Hinter{
+		10: allocHint,
+	})
+
+	vm.Context.Pc = 10
+	err := hr.RunHint(vm)
+	require.Nil(t, err)
+	require.Equal(
+		t,
+		memory.MemoryValueFromSegmentAndOffset(2, 0),
+		readFrom(vm, VM.ExecutionSegment, vm.Context.Ap+5),
+	)
+}
+
+func TestNoHint(t *testing.T) {
+	vm := defaultVirtualMachine()
+	vm.Context.Ap = 3
+
+	var ap ApCellRef = 5
+	allocHint := AllocSegment{ap}
+
+	hr := CreateHintRunner(map[uint64]Hinter{
+		10: allocHint,
+	})
+
+	vm.Context.Pc = 100
+	err := hr.RunHint(vm)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(vm.MemoryManager.Memory.Segments))
+}

--- a/pkg/hintrunner/operand.go
+++ b/pkg/hintrunner/operand.go
@@ -44,7 +44,7 @@ type Deref struct {
 }
 
 type DoubleDeref struct {
-	deref  Deref
+	deref  CellRefer
 	offset int16
 }
 
@@ -72,7 +72,7 @@ func (deref Deref) Resolve(vm *VM.VirtualMachine) (*memory.MemoryValue, error) {
 }
 
 func (dderef DoubleDeref) Resolve(vm *VM.VirtualMachine) (*memory.MemoryValue, error) {
-	cell, err := dderef.deref.deref.Get(vm)
+	cell, err := dderef.deref.Get(vm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hintrunner/operand.go
+++ b/pkg/hintrunner/operand.go
@@ -1,0 +1,126 @@
+package hintrunner
+
+import (
+	"fmt"
+	"math/big"
+
+	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
+	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
+	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
+)
+
+//
+// All CellRef definitions
+
+type CellRefer interface {
+	Get(vm *VM.VirtualMachine) (*memory.Cell, error)
+}
+
+type ApCellRef int16
+
+type FpCellRef int16
+
+func (ap ApCellRef) Get(vm *VM.VirtualMachine) (*memory.Cell, error) {
+	// todo(rodro): fix maths with safemath from ilia
+	offset := vm.Context.Ap + uint64(ap)
+	return vm.MemoryManager.Memory.Peek(VM.ExecutionSegment, offset)
+}
+
+func (fp FpCellRef) Get(vm *VM.VirtualMachine) (*memory.Cell, error) {
+	// todo(rodro): fix maths with safemath from ilia
+	offset := vm.Context.Fp + uint64(fp)
+	return vm.MemoryManager.Memory.Peek(VM.ExecutionSegment, offset)
+}
+
+//
+// All ResOperand definitions
+
+type ResOperander interface {
+	Resolve(vm *VM.VirtualMachine) (*memory.MemoryValue, error)
+}
+
+type Deref struct {
+	deref CellRefer
+}
+
+type DoubleDeref struct {
+	deref  Deref
+	offset int16
+}
+
+type Immediate big.Int
+
+type Operator uint8
+
+const (
+	Add Operator = iota
+	Mul
+)
+
+type BinaryOp struct {
+	operator Operator
+	lhs      CellRefer
+	rhs      ResOperander // (except DoubleDeref and BinaryOp)
+}
+
+func (deref Deref) Resolve(vm *VM.VirtualMachine) (*memory.MemoryValue, error) {
+	cell, err := deref.deref.Get(vm)
+	if err != nil {
+		return nil, err
+	}
+	return cell.Read(), nil
+}
+
+func (dderef DoubleDeref) Resolve(vm *VM.VirtualMachine) (*memory.MemoryValue, error) {
+	cell, err := dderef.deref.deref.Get(vm)
+	if err != nil {
+		return nil, err
+	}
+	lhs := cell.Read()
+
+	var res *memory.MemoryValue
+	if dderef.offset >= 0 {
+		rhs := memory.MemoryValueFromInt(dderef.offset)
+		res, err = memory.EmptyMemoryValueAs(lhs.IsAddress()).Add(lhs, rhs)
+	} else {
+		rhs := memory.MemoryValueFromInt(Abs(dderef.offset))
+		res, err = memory.EmptyMemoryValueAs(lhs.IsAddress()).Sub(lhs, rhs)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (imm Immediate) Resolve(vm *VM.VirtualMachine) (*memory.MemoryValue, error) {
+	felt := &f.Element{}
+	bigInt := (big.Int)(imm)
+	// todo(rodro): do we require to check that big int is lesser than P, or do we
+	// just take: big_int `mod` P?
+	felt.SetBigInt(&bigInt)
+
+	return memory.MemoryValueFromFieldElement(felt), nil
+}
+
+func (bop BinaryOp) Resolve(vm *VM.VirtualMachine) (*memory.MemoryValue, error) {
+	cell, err := bop.lhs.Get(vm)
+	if err != nil {
+		return nil, err
+	}
+	lhs := cell.Read()
+
+	rhs, err := bop.rhs.Resolve(vm)
+	if err != nil {
+		return nil, err
+	}
+
+	switch bop.operator {
+	case Add:
+		return memory.EmptyMemoryValueAs(lhs.IsAddress()).Add(lhs, rhs)
+	case Mul:
+		return memory.EmptyMemoryValueAsFelt().Mul(lhs, rhs)
+	}
+
+	return nil, fmt.Errorf("Unknown operator: %d", bop.operator)
+}

--- a/pkg/hintrunner/operand_test.go
+++ b/pkg/hintrunner/operand_test.go
@@ -1,0 +1,89 @@
+package hintrunner
+
+import (
+	"testing"
+
+	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
+	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
+	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAp(t *testing.T) {
+	vm := defaultVirtualMachine()
+	vm.Context.Ap = 5
+	writeTo(vm, VM.ExecutionSegment, vm.Context.Ap+7, memory.MemoryValueFromInt(11))
+
+	var apCell ApCellRef = 7
+	cell, err := apCell.Get(vm)
+
+	require.NoError(t, err)
+
+	value := cell.Read()
+	require.Equal(t, memory.MemoryValueFromInt(11), value)
+}
+
+func TestGetFp(t *testing.T) {
+	// todo(rodro): do this with a negative offset, when safemath merged
+}
+
+func TestResolveDeref(t *testing.T) {
+	vm := defaultVirtualMachine()
+	vm.Context.Ap = 5
+	writeTo(vm, VM.ExecutionSegment, vm.Context.Ap+7, memory.MemoryValueFromInt(11))
+
+	var apCell ApCellRef = 7
+	deref := Deref{apCell}
+
+	value, err := deref.Resolve(vm)
+
+	require.NoError(t, err)
+	require.Equal(t, memory.MemoryValueFromInt(11), value)
+}
+
+func TestResolveDoubleDerefPositiveOffset(t *testing.T) {
+	vm := defaultVirtualMachine()
+	vm.Context.Ap = 5
+	writeTo(
+		vm,
+		VM.ExecutionSegment, vm.Context.Ap+7,
+		memory.MemoryValueFromSegmentAndOffset(VM.ExecutionSegment, 0),
+	)
+	writeTo(
+		vm,
+		VM.ExecutionSegment, 14,
+		memory.MemoryValueFromInt(13),
+	)
+
+	var apCell ApCellRef = 7
+	dderf := DoubleDeref{apCell, 14}
+
+	value, err := dderf.Resolve(vm)
+	require.NoError(t, err)
+	require.Equal(t, memory.MemoryValueFromInt(13), value)
+}
+
+func TestResolveDoubleDerefNegativeOffset(t *testing.T) {
+	// todo(rodro): do this with a negative offset, when safemath merged
+}
+
+func TestResolveImmediate(t *testing.T) {
+
+}
+
+func TestResolveAddOp(t *testing.T) {
+
+}
+
+func TestResolveMulOp(t *testing.T) {
+
+}
+
+func defaultVirtualMachine() *VM.VirtualMachine {
+	vm, _ := VM.NewVirtualMachine(make([]*f.Element, 0), VM.VirtualMachineConfig{})
+	return vm
+}
+
+func writeTo(vm *VM.VirtualMachine, segment uint64, offset uint64, val *memory.MemoryValue) {
+	_ = vm.MemoryManager.Memory.Write(segment, offset, val)
+}

--- a/pkg/hintrunner/operand_test.go
+++ b/pkg/hintrunner/operand_test.go
@@ -6,7 +6,6 @@ import (
 
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
 	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
-	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -180,18 +179,4 @@ func TestResolveMulOp(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, memory.MemoryValueFromInt(500), res)
 
-}
-
-func defaultVirtualMachine() *VM.VirtualMachine {
-	vm, _ := VM.NewVirtualMachine(make([]*f.Element, 0), VM.VirtualMachineConfig{})
-	return vm
-}
-
-func writeTo(vm *VM.VirtualMachine, segment uint64, offset uint64, val *memory.MemoryValue) {
-	_ = vm.MemoryManager.Memory.Write(segment, offset, val)
-}
-
-func readFrom(vm *VM.VirtualMachine, segment uint64, offset uint64) *memory.MemoryValue {
-	val, _ := vm.MemoryManager.Memory.Read(segment, offset)
-	return val
 }

--- a/pkg/hintrunner/testutils.go
+++ b/pkg/hintrunner/testutils.go
@@ -1,0 +1,21 @@
+package hintrunner
+
+import (
+	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
+	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
+	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
+)
+
+func defaultVirtualMachine() *VM.VirtualMachine {
+	vm, _ := VM.NewVirtualMachine(make([]*f.Element, 0), VM.VirtualMachineConfig{})
+	return vm
+}
+
+func writeTo(vm *VM.VirtualMachine, segment uint64, offset uint64, val *memory.MemoryValue) {
+	_ = vm.MemoryManager.Memory.Write(segment, offset, val)
+}
+
+func readFrom(vm *VM.VirtualMachine, segment uint64, offset uint64) *memory.MemoryValue {
+	val, _ := vm.MemoryManager.Memory.Read(segment, offset)
+	return val
+}

--- a/pkg/safemath/error.go
+++ b/pkg/safemath/error.go
@@ -1,0 +1,21 @@
+package safemath
+
+import "fmt"
+
+type SafeMathError struct {
+	msg string
+}
+
+func NewSafeOffsetError(a uint64, b int16) *SafeMathError {
+	return &SafeMathError{
+		msg: fmt.Sprintf("offset calculation of %d using %d is out of [0, 2**64) range", a, b),
+	}
+}
+
+func (e *SafeMathError) Error() string {
+	return fmt.Sprintf("math error: %s", e.msg)
+}
+
+func (e *SafeMathError) Unwrap() error {
+	return nil
+}

--- a/pkg/safemath/safemath.go
+++ b/pkg/safemath/safemath.go
@@ -26,12 +26,12 @@ func SafeOffset(x uint64, y int16) (res uint64, isOverflow bool) {
 	res = x + enlargedY
 	// Why does this work?
 	// Let's proceed by cases on the most significant bit of (MSB(x)).
-	// If MSB(x) == 1 and enlargedY < 0 (MSB(enlargedY) == 1) then overflow doesn't happen.
-	// Let's consider the case enlargedY >= 0 (MSB(enlargedY) == 0).
+	// If MSB(x) == 1 and y < 0 (MSB(y) == 1) then overflow doesn't happen.
+	// Let's consider the case y >= 0 (MSB(y) == 0).
 	// In that case we can only wrap up by going to the begining of uint64 range making the MSB(res) = 0.
 	// This is the second disjunct of the disjunctive formula.
 	//
-	// In the same fashion the case MSB(x) == 0 and MSB(enlargedY) == 1 is reasoned about.
+	// In the same fashion the case MSB(x) == 0 and MSB(y) == 1 is reasoned about.
 	//
 	// Finally, we boil everything down to MSBs by rotating and anding with ...000001.
 	isOverflow = bits.RotateLeft64((^x&enlargedY&res)|(x & ^enlargedY & ^res), 1)&0x1 != 0

--- a/pkg/vm/memory/memory_value.go
+++ b/pkg/vm/memory/memory_value.go
@@ -16,7 +16,7 @@ type MemoryAddress struct {
 }
 
 // Creates a new memory address
-func CreateMemoryAddress(segment uint64, offset uint64) *MemoryAddress {
+func NewMemoryAddress(segment uint64, offset uint64) *MemoryAddress {
 	return &MemoryAddress{SegmentIndex: segment, Offset: offset}
 }
 
@@ -46,6 +46,13 @@ func (address *MemoryAddress) Sub(lhs *MemoryAddress, rhs any) (*MemoryAddress, 
 
 	// Then update offset accordingly
 	switch t := rhs.(type) {
+	case uint64:
+		rhs64 := rhs.(uint64)
+		if rhs64 > lhs.Offset {
+			return nil, fmt.Errorf("rhs offset greater than lhs offset")
+		}
+		address.Offset = lhs.Offset - rhs64
+		return address, nil
 	case *f.Element:
 		feltRhs := rhs.(*f.Element)
 		if !feltRhs.IsUint64() {
@@ -55,7 +62,11 @@ func (address *MemoryAddress) Sub(lhs *MemoryAddress, rhs any) (*MemoryAddress, 
 				feltRhs.String(),
 			)
 		}
-		address.Offset = lhs.Offset - feltRhs.Uint64()
+		feltRhs64 := feltRhs.Uint64()
+		if feltRhs64 > lhs.Offset {
+			return nil, fmt.Errorf("rhs offset greater than lhs offset")
+		}
+		address.Offset = lhs.Offset - feltRhs64
 		return address, nil
 	case *MemoryAddress:
 		addressRhs := rhs.(*MemoryAddress)
@@ -65,6 +76,9 @@ func (address *MemoryAddress) Sub(lhs *MemoryAddress, rhs any) (*MemoryAddress, 
 				addressRhs.String(),
 				lhs.String(),
 			)
+		}
+		if addressRhs.Offset > lhs.Offset {
+			return nil, fmt.Errorf("rhs offset greater than lhs offset")
 		}
 		address.Offset = lhs.Offset - addressRhs.Offset
 		return address, nil

--- a/pkg/vm/memory/memory_value.go
+++ b/pkg/vm/memory/memory_value.go
@@ -115,7 +115,7 @@ func MemoryValueFromInt[T constraints.Integer](v T) *MemoryValue {
 	}
 }
 
-func MemoryValueFromSegmentAndOffset[T constraints.Integer](segmentIndex T, offset T) *MemoryValue {
+func MemoryValueFromSegmentAndOffset[T constraints.Integer](segmentIndex, offset T) *MemoryValue {
 	return &MemoryValue{
 		address: &MemoryAddress{SegmentIndex: uint64(segmentIndex), Offset: uint64(offset)},
 	}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -201,13 +201,13 @@ func (vm *VirtualMachine) getCellOp1(instruction *Instruction, op0Cell *mem.Cell
 		if err != nil {
 			return nil, fmt.Errorf("expected op0 to be an address: %w", err)
 		}
-		op1Address = mem.CreateMemoryAddress(op0Address.SegmentIndex, op0Address.Offset)
+		op1Address = mem.NewMemoryAddress(op0Address.SegmentIndex, op0Address.Offset)
 	case Imm:
-		op1Address = mem.CreateMemoryAddress(ProgramSegment, vm.Context.Pc)
+		op1Address = mem.NewMemoryAddress(ProgramSegment, vm.Context.Pc)
 	case FpPlusOffOp1:
-		op1Address = mem.CreateMemoryAddress(ExecutionSegment, vm.Context.Fp)
+		op1Address = mem.NewMemoryAddress(ExecutionSegment, vm.Context.Fp)
 	case ApPlusOffOp1:
-		op1Address = mem.CreateMemoryAddress(ExecutionSegment, vm.Context.Ap)
+		op1Address = mem.NewMemoryAddress(ExecutionSegment, vm.Context.Ap)
 	}
 
 	addr, isOverflow := safemath.SafeOffset(op1Address.Offset, instruction.OffOp1)

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -21,8 +21,8 @@ func TestVMCreation(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, vm.MemoryManager.Memory.Segments, 2)
-	assert.Len(t, vm.MemoryManager.Memory.Segments[programSegment].Data, len(dummyBytecode))
-	assert.Empty(t, vm.MemoryManager.Memory.Segments[executionSegment].Data)
+	assert.Len(t, vm.MemoryManager.Memory.Segments[ProgramSegment].Data, len(dummyBytecode))
+	assert.Empty(t, vm.MemoryManager.Memory.Segments[ExecutionSegment].Data)
 }
 
 // todo(rodro): test all possible ways of:
@@ -278,7 +278,7 @@ func (vm *VirtualMachine) TestUpdateFp(t *testing.T) {
 }
 
 func writeToDataSegment(vm *VirtualMachine, index uint64, value *mem.MemoryValue) {
-	err := vm.MemoryManager.Memory.Write(executionSegment, index, value)
+	err := vm.MemoryManager.Memory.Write(ExecutionSegment, index, value)
 	if err != nil {
 		panic("error in test util: writeToDataSegment")
 	}

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -178,7 +178,7 @@ func TestComputeAddRes(t *testing.T) {
 	cellOp0 := &mem.Cell{
 		Accessed: true,
 		Value: mem.MemoryValueFromMemoryAddress(
-			mem.CreateMemoryAddress(2, 10),
+			mem.NewMemoryAddress(2, 10),
 		),
 	}
 
@@ -191,7 +191,7 @@ func TestComputeAddRes(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := mem.MemoryValueFromMemoryAddress(
-		mem.CreateMemoryAddress(2, 25),
+		mem.NewMemoryAddress(2, 25),
 	)
 
 	assert.Equal(t, expected, res)
@@ -206,7 +206,7 @@ func (vm *VirtualMachine) TestOpcodeAssertionAssertEq(t *testing.T) {
 	}
 
 	dstCell := mem.Cell{}
-	res := mem.MemoryValueFromMemoryAddress(mem.CreateMemoryAddress(2, 10))
+	res := mem.MemoryValueFromMemoryAddress(mem.NewMemoryAddress(2, 10))
 
 	err = vm.opcodeAssertions(&instruction, &dstCell, nil, res)
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func (vm *VirtualMachine) TestOpcodeAssertionAssertEq(t *testing.T) {
 		t,
 		mem.Cell{
 			Accessed: true,
-			Value:    mem.MemoryValueFromMemoryAddress(mem.CreateMemoryAddress(2, 10))},
+			Value:    mem.MemoryValueFromMemoryAddress(mem.NewMemoryAddress(2, 10))},
 		dstCell,
 	)
 }


### PR DESCRIPTION
Added a `Hintrunner` as an external component for the VM. The `Hintrunner` is the part of the project that will run the hints by  which would allow for any of the users of the VM to define their own hints if they want.

This will also favor atomic and parallel works on hints, since all the tools for interacting with the VM for hints has been implemented.

`Alloc` and `TestLessThan` hints are implemented as well as use example.

Fixes #31 