### PR TITLE
make felt and address in MemoryValue share the same bytes

### DIFF
--- a/pkg/vm/memory/memory_manager.go
+++ b/pkg/vm/memory/memory_manager.go
@@ -49,7 +49,7 @@ func (mm *MemoryManager) RelocateMemory() []*f.Element {
 
 			var felt *f.Element
 			if cell.IsAddress() {
-				felt = cell.address.Relocate(segmentsOffsets)
+				felt = cell.addrUnsafe().Relocate(segmentsOffsets)
 			} else {
 				felt = &cell.felt
 			}


### PR DESCRIPTION
This is essentially a poor mans union.

``` c
struct {
   union {
       felt f.Element
       memoryAddress MemoryAddress
   }
   bool isFelt
   bool isMemoryAddress
}

```


This results in a smaller `MemoryValue`.
Helps us in 2 ways,

Makes segments take less space in memory (less total memory consumption)
and makes copying MemoryValue instances cheaper since there are less bytes to copy (speed up)


Before;

```
BenchmarkVMRun-16    	Loading program at /home/omer/Documents/cairo-vm-go/fib_compiled.json
Running....
      93	  12089788 ns/op	11495034 B/op	      44 allocs/op
PASS
```

After

```
BenchmarkVMRun-16    	Loading program at /home/omer/Documents/cairo-vm-go/fib_compiled.json
Running....
     100	  11596486 ns/op	 8215796 B/op	      44 allocs/op
PASS
```

a marginal speed up and a significant reduction in total memory allocated.