### PR TITLE
Feat: Adds failure on reading from unknown values

### DIFF
--- a/pkg/runners/zero/zero.go
+++ b/pkg/runners/zero/zero.go
@@ -77,11 +77,11 @@ func (runner *ZeroRunner) InitializeMainEntrypoint() (memory.MemoryAddress, erro
 	if runner.proofmode {
 		initialPCOffset, ok := runner.program.Labels["__start__"]
 		if !ok {
-			return memory.UnknownValue, errors.New("start label not found. Try compiling with `--proof_mode`")
+			return memory.UnknownAddress, errors.New("start label not found. Try compiling with `--proof_mode`")
 		}
 		endPcOffset, ok := runner.program.Labels["__end__"]
 		if !ok {
-			return memory.UnknownValue, errors.New("end label not found. Try compiling with `--proof_mode`")
+			return memory.UnknownAddress, errors.New("end label not found. Try compiling with `--proof_mode`")
 		}
 
 		// Add the dummy last fp and pc to the public memory, so that the verifier can enforce [fp - 2] = fp.
@@ -107,7 +107,7 @@ func (runner *ZeroRunner) InitializeEntrypoint(
 ) (memory.MemoryAddress, error) {
 	initialPCOffset, ok := runner.program.Entrypoints[funcName]
 	if !ok {
-		return memory.UnknownValue, fmt.Errorf("unknown entrypoint: %s", funcName)
+		return memory.UnknownAddress, fmt.Errorf("unknown entrypoint: %s", funcName)
 	}
 
 	stack := make([]memory.MemoryValue, 0, len(arguments)+2) // end + fp

--- a/pkg/vm/builtins/range_check.go
+++ b/pkg/vm/builtins/range_check.go
@@ -1,6 +1,7 @@
 package builtins
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
@@ -15,17 +16,20 @@ var max128 = fp.Element{18446744073700081665, 17407, 18446744073709551584, 57646
 func (r *RangeCheck) CheckWrite(segment *memory.Segment, offset uint64, value *memory.MemoryValue) error {
 	felt, err := value.FieldElement()
 	if err != nil {
-		return err
+		return fmt.Errorf("check write: %w", err)
 	}
 
 	// felt >= (2^128)
 	if felt.Cmp(&max128) != -1 {
-		return fmt.Errorf("range check builtin failed for value %s", value)
+		return fmt.Errorf("check write: 2**128 < %s", value)
 	}
 	return nil
 }
 
 func (r *RangeCheck) InferValue(segment *memory.Segment, offset uint64) error {
-	segment.Data[offset] = memory.EmptyMemoryValueAsFelt()
-	return nil
+	return errors.New("cannot infer value")
+}
+
+func (r *RangeCheck) String() string {
+	return "range_check"
 }

--- a/pkg/vm/builtins/range_check_test.go
+++ b/pkg/vm/builtins/range_check_test.go
@@ -34,6 +34,5 @@ func TestRangeCheckWrite(t *testing.T) {
 func TestRangeCheckInfer(t *testing.T) {
 	builtin := RangeCheck{}
 	segment := memory.EmptySegmentWithLength(3)
-	assert.NoError(t, builtin.InferValue(segment, 0))
-	require.Equal(t, memory.EmptyMemoryValueAsFelt(), segment.Data[0])
+	assert.ErrorContains(t, builtin.InferValue(segment, 0), "cannot infer value")
 }

--- a/pkg/vm/memory/memory.go
+++ b/pkg/vm/memory/memory.go
@@ -206,8 +206,8 @@ func (memory *Memory) AllocateEmptySegment() int {
 	return len(memory.Segments) - 1
 }
 
-// Writes to a memory address a new memory value. Errors if writing to an unallocated
-// space or if rewriting a specific cell
+// Writes to a given segment index and offset a new memory value. Errors if writing
+// to an unallocated segment or if overwriting a different memory value
 func (memory *Memory) Write(segmentIndex uint64, offset uint64, value *MemoryValue) error {
 	if segmentIndex >= uint64(len(memory.Segments)) {
 		return fmt.Errorf("segment %d: unallocated", segmentIndex)
@@ -218,13 +218,14 @@ func (memory *Memory) Write(segmentIndex uint64, offset uint64, value *MemoryVal
 	return nil
 }
 
+// Writes to a memory address a new memory value. Errors if writing to an unallocated
+// segment or if overwriting a different memory value
 func (memory *Memory) WriteToAddress(address *MemoryAddress, value *MemoryValue) error {
 	return memory.Write(address.SegmentIndex, address.Offset, value)
 }
 
 // Reads a memory value given the segment index and offset. Errors if reading from
-// an unallocated space. If reading a cell which hasn't been accesed before, it is
-// initalized with its default zero value
+// an unallocated segment or if reading an unknown memory value
 func (memory *Memory) Read(segmentIndex uint64, offset uint64) (MemoryValue, error) {
 	if segmentIndex >= uint64(len(memory.Segments)) {
 		return MemoryValue{}, fmt.Errorf("segment %d: unallocated", segmentIndex)
@@ -236,15 +237,14 @@ func (memory *Memory) Read(segmentIndex uint64, offset uint64) (MemoryValue, err
 	return mv, nil
 }
 
-// Reads a memory value from a memory address. Errors if reading from an unallocated
-// space. If reading a cell which hasn't been accesed before, it is initalized with
-// its default zero value
+// Reads a memory value given an address. Errors if reading from
+// an unallocated segment or if reading an unknown memory value
 func (memory *Memory) ReadFromAddress(address *MemoryAddress) (MemoryValue, error) {
 	return memory.Read(address.SegmentIndex, address.Offset)
 }
 
 // Given a segment index and offset, returns the memory value at that position, without
-// modifying it in any way. Errors if reading from an unallocated space
+// modifying it in any way. Errors if peeking from an unallocated segment
 func (memory *Memory) Peek(segmentIndex uint64, offset uint64) (MemoryValue, error) {
 	if segmentIndex >= uint64(len(memory.Segments)) {
 		return MemoryValue{}, fmt.Errorf("segment %d: unallocated", segmentIndex)
@@ -252,7 +252,8 @@ func (memory *Memory) Peek(segmentIndex uint64, offset uint64) (MemoryValue, err
 	return memory.Segments[segmentIndex].Peek(offset), nil
 }
 
-// Given a Memory Address returns a pointer to the Memory Cell
+// Given an address returns the memory value at that position, without
+// modifying it in any way. Errors if peeking from an unallocated segment
 func (memory *Memory) PeekFromAddress(address *MemoryAddress) (MemoryValue, error) {
 	return memory.Peek(address.SegmentIndex, address.Offset)
 }

--- a/pkg/vm/memory/memory_value.go
+++ b/pkg/vm/memory/memory_value.go
@@ -17,7 +17,7 @@ type MemoryAddress struct {
 	Offset       uint64
 }
 
-var UnknownValue = MemoryAddress{}
+var UnknownAddress = MemoryAddress{}
 
 func (address *MemoryAddress) Equal(other *MemoryAddress) bool {
 	return address.SegmentIndex == other.SegmentIndex && address.Offset == other.Offset
@@ -98,6 +98,8 @@ type MemoryValue struct {
 	isFelt    bool
 	isAddress bool
 }
+
+var UnknownValue = MemoryValue{}
 
 func MemoryValueFromMemoryAddress(address *MemoryAddress) MemoryValue {
 	v := MemoryValue{


### PR DESCRIPTION
* Make the VM fail when reading an unknown memory value
* Make Builtin inference fail when it is not supposed to infer anything
* UnknownValue is now UnknownAddress for Empty Addresses and UnknownValue are now Empty Values
* Update tests accordingly

Resolves #100 