### PR TITLE
Fix(assembler): increase parser lookahead

### DIFF
--- a/pkg/assembler/assembler.go
+++ b/pkg/assembler/assembler.go
@@ -9,7 +9,7 @@ var parser *participle.Parser[CasmProgram] = participle.MustBuild[CasmProgram](
 	// mandatory lookahead to disambiguate between productions:
 	// expr -> [reg + n] + [reg + m] and
 	// expr -> [reg + n]
-	participle.UseLookahead(5),
+	participle.UseLookahead(7),
 )
 
 func CasmToBytecode(code string) ([]*f.Element, error) {

--- a/pkg/assembler/grammar_test.go
+++ b/pkg/assembler/grammar_test.go
@@ -1,6 +1,7 @@
 package assembler
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -196,6 +197,52 @@ func TestRetGrammar(t *testing.T) {
 		},
 		casmAst,
 	)
+}
+
+func TestJumpGrammar(t *testing.T) {
+	for _, jmpType := range []string{"abs", "rel"} {
+		t.Logf("jmpType: %s", jmpType)
+
+		code := fmt.Sprintf("jmp %s [ap + 1] + [fp - 7];", jmpType)
+
+		casmAst, err := parseCode(code)
+		require.NoError(t, err)
+
+		require.Equal(
+			t,
+			&CasmProgram{
+				[]InstructionNode{
+					{
+						Jump: &Jump{
+							JumpType: jmpType,
+							Value: &Expression{
+								MathOperation: &MathOperation{
+									Lhs: &Deref{
+										Name: "ap",
+										Offset: &Offset{
+											Sign:  "+",
+											Value: ptrOf(1),
+										},
+									},
+									Rhs: &DerefOrImm{
+										Deref: &Deref{
+											Name: "fp",
+											Offset: &Offset{
+												Sign:  "-",
+												Value: ptrOf(7),
+											},
+										},
+									},
+									Operator: "+",
+								},
+							},
+						},
+					},
+				},
+			},
+			casmAst,
+		)
+	}
 }
 
 func ptrOf[T any](n T) *T {


### PR DESCRIPTION
Increase parser look ahead so it could select the right production to expand. It couldn't correctly decide between these two instructions:

* jmp rel expr
* jmp rel <dst> if <exrp> != 0

Fixes #104 