### PR TITLE
Fix testall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ integration:
 
 testall:
 	@echo "Running all tests..."
+	@$(MAKE) build
 	@go test ./...
 
 bench:


### PR DESCRIPTION
`make testall` fails integration tests with:
```
--- FAIL: TestCairoZeroFiles (7.46s)
    cairozero_test.go:36: testing: cairo_files/factorial.cairo
    cairozero_test.go:52: cairo-vm run cairo_files/factorial_compiled.json: fork/exec ../bin/cairo-vm: no such file or directory

    cairozero_test.go:36: testing: cairo_files/fib.cairo
    cairozero_test.go:52: cairo-vm run cairo_files/fib_compiled.json: fork/exec ../bin/cairo-vm: no such file or directory

    cairozero_test.go:36: testing: cairo_files/simple.cairo
    cairozero_test.go:52: cairo-vm run cairo_files/simple_compiled.json: fork/exec ../bin/cairo-vm: no such file or directory

--- FAIL: TestFailingRangeCheck (1.05s)
    cairozero_test.go:247:
        	Error Trace:	/home/jmjac/go/src/github.com/NethermindEth/cairo-vm-go/integration_tests/cairozero_test.go:247
        	Error:      	Error "cairo-vm run builtin_tests/range_check_compiled.json: fork/exec ../bin/cairo-vm: no such file or directory\n" does not contain "check write: 2**128 <"
        	Test:       	TestFailingRangeCheck
--- FAIL: TestBitwise (1.18s)
    cairozero_test.go:257:
        	Error Trace:	/home/jmjac/go/src/github.com/NethermindEth/cairo-vm-go/integration_tests/cairozero_test.go:257
        	Error:      	Received unexpected error:
        	            	cairo-vm run builtin_tests/bitwise_builtin_test_compiled.json: fork/exec ../bin/cairo-vm: no such file or directory
        	Test:       	TestBitwise
--- FAIL: TestPedersen (1.20s)
    cairozero_test.go:267:
        	Error Trace:	/home/jmjac/go/src/github.com/NethermindEth/cairo-vm-go/integration_tests/cairozero_test.go:267
        	Error:      	Received unexpected error:
        	            	cairo-vm run builtin_tests/pedersen_test_compiled.json: fork/exec ../bin/cairo-vm: no such file or directory
        	Test:       	TestPedersen
FAIL
```
if cairo-vm binary is not present. Can also lead to using a binary from different branch when switching branches. I think we should make sure cairo-vm is rebuild before running all tests