### PR TITLE
Feat: debugPrint hint

### DIFF
--- a/pkg/hintrunner/hint.go
+++ b/pkg/hintrunner/hint.go
@@ -215,3 +215,46 @@ func (hint WideMul128) Execute(vm *VM.VirtualMachine) error {
 
 	return nil
 }
+
+type DebugPrint struct {
+	start ResOperander
+	end   ResOperander
+}
+
+func (hint DebugPrint) Execute(vm *VM.VirtualMachine) error {
+	start, err := hint.start.Resolve(vm)
+	if err != nil {
+		return fmt.Errorf("resolve start operand %s: %v", hint.start, err)
+	}
+
+	startAddr, err := start.MemoryAddress()
+	if err != nil {
+		return fmt.Errorf("start memory address: %v", err)
+	}
+
+	end, err := hint.end.Resolve(vm)
+	if err != nil {
+		return fmt.Errorf("resolve rhs operand %s: %v", hint.end, err)
+	}
+	endAddr, err := end.MemoryAddress()
+	if err != nil {
+		return fmt.Errorf("end memory address: %v", err)
+	}
+
+	if startAddr.Offset > endAddr.Offset {
+		return fmt.Errorf("start cannot be greater than end")
+	}
+
+	current := startAddr.Offset
+	for current < endAddr.Offset {
+		fmt.Printf("[DEBUG] %x\n", current)
+		current += 1
+	}
+	//v, err := vm.Memory.ReadFromAddress(startAddr)
+
+	//if err != nil {
+	//	return fmt.Errorf("read memory address %s: %v", err)
+	//}
+
+	return nil
+}

--- a/pkg/hintrunner/hint.go
+++ b/pkg/hintrunner/hint.go
@@ -253,13 +253,9 @@ func (hint DebugPrint) Execute(vm *VM.VirtualMachine) error {
 			return err
 		}
 
-		fmt.Printf("[DEBUG] %s\n", v)
+		fmt.Printf("[DEBUG] %s\n", v.Hex())
 		current += 1
 	}
-
-	//if err != nil {
-	//	return fmt.Errorf("read memory address %s: %v", err)
-	//}
 
 	return nil
 }

--- a/pkg/hintrunner/hint_test.go
+++ b/pkg/hintrunner/hint_test.go
@@ -1,6 +1,7 @@
 package hintrunner
 
 import (
+	"fmt"
 	"io"
 	"math/big"
 	"os"
@@ -256,11 +257,12 @@ func TestDebugPrint(t *testing.T) {
 		start: start,
 		end:   end,
 	}
-	expected := []byte("[DEBUG] 10\n[DEBUG] 20\n[DEBUG] 30\n")
+	expected := []byte("[DEBUG] a\n[DEBUG] 14\n[DEBUG] 1e\n")
 	err := hint.Execute(vm)
 
 	w.Close()
 	out, _ := io.ReadAll(r)
+	fmt.Println(string(out))
 	//Restore stdout at the end of the test
 	os.Stdout = rescueStdout
 

--- a/pkg/hintrunner/hint_test.go
+++ b/pkg/hintrunner/hint_test.go
@@ -1,10 +1,7 @@
 package hintrunner
 
 import (
-	"fmt"
-	"io"
 	"math/big"
-	"os"
 	"testing"
 
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
@@ -238,10 +235,10 @@ func TestWideMul128IncorrectRange(t *testing.T) {
 func TestDebugPrint(t *testing.T) {
 
 	//Save the old stdout
-	rescueStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
+	//	rescueStdout := os.Stdout
+	//	r, w, _ := os.Pipe()
+	//	os.Stdout = w
+	//
 	vm := defaultVirtualMachine()
 	vm.Context.Ap = 0
 	vm.Context.Fp = 0
@@ -252,19 +249,21 @@ func TestDebugPrint(t *testing.T) {
 	v = memory.MemoryValueFromInt(30)
 	vm.Memory.Write(VM.ExecutionSegment, 2, &v)
 
-	start := Immediate(*big.NewInt(0))
-	end := Immediate(*big.NewInt(2))
+	var startRef ApCellRef = 0
+	var endRef FpCellRef = 3
+	start := Deref{startRef}
+	end := Deref{endRef}
 	hint := DebugPrint{
 		start: start,
 		end:   end,
 	}
 	err := hint.Execute(vm)
 
-	w.Close()
-	out, _ := io.ReadAll(r)
-	//Restore stdout at the end of the test
-	os.Stdout = rescueStdout
+	//w.Close()
+	//out, _ := io.ReadAll(r)
+	////Restore stdout at the end of the test
+	//os.Stdout = rescueStdout
 
-	fmt.Println(out)
+	//fmt.Println(out)
 	require.NoError(t, err)
 }

--- a/pkg/hintrunner/hint_test.go
+++ b/pkg/hintrunner/hint_test.go
@@ -1,7 +1,6 @@
 package hintrunner
 
 import (
-	"fmt"
 	"io"
 	"math/big"
 	"os"
@@ -245,13 +244,15 @@ func TestDebugPrint(t *testing.T) {
 	vm.Context.Ap = 0
 	vm.Context.Fp = 0
 
-	writeTo(vm, VM.ExecutionSegment, 0, memory.MemoryValueFromInt(10))
-	writeTo(vm, VM.ExecutionSegment, 1, memory.MemoryValueFromInt(20))
-	writeTo(vm, VM.ExecutionSegment, 2, memory.MemoryValueFromInt(30))
+	writeTo(vm, VM.ExecutionSegment, 0, memory.MemoryValueFromSegmentAndOffset(VM.ExecutionSegment, 2))
+	writeTo(vm, VM.ExecutionSegment, 1, memory.MemoryValueFromSegmentAndOffset(VM.ExecutionSegment, 5))
+	writeTo(vm, VM.ExecutionSegment, 2, memory.MemoryValueFromInt(10))
+	writeTo(vm, VM.ExecutionSegment, 3, memory.MemoryValueFromInt(20))
+	writeTo(vm, VM.ExecutionSegment, 4, memory.MemoryValueFromInt(30))
 
-	var startRef ApCellRef = 0
-	var endRef FpCellRef = 3
-	start := Deref{startRef}
+	var starRef ApCellRef = 0
+	var endRef ApCellRef = 1
+	start := Deref{starRef}
 	end := Deref{endRef}
 	hint := DebugPrint{
 		start: start,
@@ -262,10 +263,9 @@ func TestDebugPrint(t *testing.T) {
 
 	w.Close()
 	out, _ := io.ReadAll(r)
-	fmt.Println(string(out))
 	//Restore stdout at the end of the test
 	os.Stdout = rescueStdout
 
 	require.NoError(t, err)
-	require.Equal(t, out, expected)
+	require.Equal(t, expected, out)
 }

--- a/pkg/hintrunner/hint_test.go
+++ b/pkg/hintrunner/hint_test.go
@@ -1,7 +1,9 @@
 package hintrunner
 
 import (
+	"io"
 	"math/big"
+	"os"
 	"testing"
 
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
@@ -235,10 +237,10 @@ func TestWideMul128IncorrectRange(t *testing.T) {
 func TestDebugPrint(t *testing.T) {
 
 	//Save the old stdout
-	//	rescueStdout := os.Stdout
-	//	r, w, _ := os.Pipe()
-	//	os.Stdout = w
-	//
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
 	vm := defaultVirtualMachine()
 	vm.Context.Ap = 0
 	vm.Context.Fp = 0
@@ -257,13 +259,14 @@ func TestDebugPrint(t *testing.T) {
 		start: start,
 		end:   end,
 	}
+	expected := []byte("[DEBUG] 10\n[DEBUG] 20\n[DEBUG] 30\n")
 	err := hint.Execute(vm)
 
-	//w.Close()
-	//out, _ := io.ReadAll(r)
-	////Restore stdout at the end of the test
-	//os.Stdout = rescueStdout
+	w.Close()
+	out, _ := io.ReadAll(r)
+	//Restore stdout at the end of the test
+	os.Stdout = rescueStdout
 
-	//fmt.Println(out)
 	require.NoError(t, err)
+	require.Equal(t, out, expected)
 }

--- a/pkg/hintrunner/hint_test.go
+++ b/pkg/hintrunner/hint_test.go
@@ -235,7 +235,6 @@ func TestWideMul128IncorrectRange(t *testing.T) {
 }
 
 func TestDebugPrint(t *testing.T) {
-
 	//Save the old stdout
 	rescueStdout := os.Stdout
 	r, w, _ := os.Pipe()
@@ -244,12 +243,10 @@ func TestDebugPrint(t *testing.T) {
 	vm := defaultVirtualMachine()
 	vm.Context.Ap = 0
 	vm.Context.Fp = 0
-	v := memory.MemoryValueFromInt(10)
-	vm.Memory.Write(VM.ExecutionSegment, 0, &v)
-	v = memory.MemoryValueFromInt(20)
-	vm.Memory.Write(VM.ExecutionSegment, 1, &v)
-	v = memory.MemoryValueFromInt(30)
-	vm.Memory.Write(VM.ExecutionSegment, 2, &v)
+
+	writeTo(vm, VM.ExecutionSegment, 0, memory.MemoryValueFromInt(10))
+	writeTo(vm, VM.ExecutionSegment, 1, memory.MemoryValueFromInt(20))
+	writeTo(vm, VM.ExecutionSegment, 2, memory.MemoryValueFromInt(30))
 
 	var startRef ApCellRef = 0
 	var endRef FpCellRef = 3

--- a/pkg/vm/memory/memory_value.go
+++ b/pkg/vm/memory/memory_value.go
@@ -88,6 +88,12 @@ func (address MemoryAddress) String() string {
 	)
 }
 
+func (address MemoryAddress) Hex() string {
+	return fmt.Sprintf(
+		"%x:%x", address.SegmentIndex, address.Offset,
+	)
+}
+
 // Stores all posible types that can be stored in a Memory cell,
 //
 //   - either a Felt value (an `f.Element`),
@@ -273,6 +279,13 @@ func (mv MemoryValue) String() string {
 		return mv.addrUnsafe().String()
 	}
 	return mv.felt.String()
+}
+
+func (mv MemoryValue) Hex() string {
+	if mv.IsAddress() {
+		return fmt.Sprintf("%x", mv.addrUnsafe())
+	}
+	return mv.felt.Text(16)
 }
 
 // Retuns a MemoryValue holding a felt as uint if it fits

--- a/pkg/vm/memory/memory_value.go
+++ b/pkg/vm/memory/memory_value.go
@@ -88,12 +88,6 @@ func (address MemoryAddress) String() string {
 	)
 }
 
-func (address MemoryAddress) Hex() string {
-	return fmt.Sprintf(
-		"%x:%x", address.SegmentIndex, address.Offset,
-	)
-}
-
 // Stores all posible types that can be stored in a Memory cell,
 //
 //   - either a Felt value (an `f.Element`),
@@ -279,13 +273,6 @@ func (mv MemoryValue) String() string {
 		return mv.addrUnsafe().String()
 	}
 	return mv.felt.String()
-}
-
-func (mv MemoryValue) Hex() string {
-	if mv.IsAddress() {
-		return fmt.Sprintf("%x", mv.addrUnsafe())
-	}
-	return mv.felt.Text(16)
 }
 
 // Retuns a MemoryValue holding a felt as uint if it fits


### PR DESCRIPTION
Resolves #124.  As I understand this hint handles printing values between `start` and `end` addresses. I don't like getting underlying type of `ResOperand` but this seems to be necessary to figure out how many values do we need to print. Also this won't work with `Immediate` because it's a value not an address 