### PR TITLE
More tests for assert equal Instruction

### DIFF
--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -927,6 +927,78 @@ func TestAssertEqualInstruction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, mem.MemoryValueFromInt(-5), mv)
 	})
+
+	t.Run("multiply", func(t *testing.T){
+		vm:= defaultVirtualMachineWithCode("[ap] = [ap - 1] * [fp];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Fp, 5)
+		writeToDataSegment(vm, vm.Context.Ap-1, 10)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Ap)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(50), mv)
+	})
+
+	t.Run("comparison equality", func(t *testing.T){
+		vm:= defaultVirtualMachineWithCode("[ap + 1] = [fp];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Ap+1, 5)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(5), mv)
+	})
+
+	t.Run("comparison equality 2", func(t *testing.T){
+		vm:= defaultVirtualMachineWithCode("[ap - 1] = [fp];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Ap-1, 7)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(7), mv)
+	})
+
+	t.Run("compare register values", func(t *testing.T){
+		vm:=defaultVirtualMachineWithCode("[ap] = [fp];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Ap, 3)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(3), mv)
+	})
+
+	t.Run("compare register values left to right", func(t *testing.T){
+		vm:=defaultVirtualMachineWithCode("[fp] = [ap - 1];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Ap-1, 10)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(10), mv)
+	})
+
 }
 
 // ======================

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -943,63 +943,23 @@ func TestAssertEqualInstruction(t *testing.T) {
 		assert.Equal(t, mem.MemoryValueFromInt(50), mv)
 	})
 
-	t.Run("comparison equality", func(t *testing.T){
-		vm:= defaultVirtualMachineWithCode("[ap + 1] = [fp];")
+	t.Run("division", func(t *testing.T){
+		vm:= defaultVirtualMachineWithCode("[ap] = [ap + 1] * [fp];")
 		setInitialReg(vm, 3, 1, 0)
 
-		writeToDataSegment(vm, vm.Context.Ap+1, 5)
+		writeToDataSegment(vm, vm.Context.Fp, 2)
+		writeToDataSegment(vm, vm.Context.Ap, 10)
 
 		err:= vm.RunStep(&hintrunner)
 		require.NoError(t, err)
 
-		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Ap+1)
 		require.NoError(t, err)
 		assert.Equal(t, mem.MemoryValueFromInt(5), mv)
 	})
 
-	t.Run("comparison equality 2", func(t *testing.T){
-		vm:= defaultVirtualMachineWithCode("[ap - 1] = [fp];")
-		setInitialReg(vm, 3, 1, 0)
-
-		writeToDataSegment(vm, vm.Context.Ap-1, 7)
-
-		err:= vm.RunStep(&hintrunner)
-		require.NoError(t, err)
-
-		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
-		require.NoError(t, err)
-		assert.Equal(t, mem.MemoryValueFromInt(7), mv)
-	})
-
-	t.Run("compare register values", func(t *testing.T){
-		vm:=defaultVirtualMachineWithCode("[ap] = [fp];")
-		setInitialReg(vm, 3, 1, 0)
-
-		writeToDataSegment(vm, vm.Context.Ap, 3)
-
-		err:= vm.RunStep(&hintrunner)
-		require.NoError(t, err)
-
-		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
-		require.NoError(t, err)
-		assert.Equal(t, mem.MemoryValueFromInt(3), mv)
-	})
-
-	t.Run("compare register values left to right", func(t *testing.T){
-		vm:=defaultVirtualMachineWithCode("[fp] = [ap - 1];")
-		setInitialReg(vm, 3, 1, 0)
-
-		writeToDataSegment(vm, vm.Context.Ap-1, 10)
-
-		err:= vm.RunStep(&hintrunner)
-		require.NoError(t, err)
-
-		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
-		require.NoError(t, err)
-		assert.Equal(t, mem.MemoryValueFromInt(10), mv)
-	})
-
 }
+
 
 // ======================
 // Test Memory Relocation

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -928,14 +928,14 @@ func TestAssertEqualInstruction(t *testing.T) {
 		assert.Equal(t, mem.MemoryValueFromInt(-5), mv)
 	})
 
-	t.Run("multiply", func(t *testing.T){
-		vm:= defaultVirtualMachineWithCode("[ap] = [ap - 1] * [fp];")
+	t.Run("multiplication", func(t *testing.T) {
+		vm := defaultVirtualMachineWithCode("[ap] = [ap - 1] * [fp];")
 		setInitialReg(vm, 3, 1, 0)
 
 		writeToDataSegment(vm, vm.Context.Fp, 5)
 		writeToDataSegment(vm, vm.Context.Ap-1, 10)
 
-		err:= vm.RunStep(&hintrunner)
+		err := vm.RunStep(&hintrunner)
 		require.NoError(t, err)
 
 		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Ap)
@@ -943,14 +943,14 @@ func TestAssertEqualInstruction(t *testing.T) {
 		assert.Equal(t, mem.MemoryValueFromInt(50), mv)
 	})
 
-	t.Run("division", func(t *testing.T){
-		vm:= defaultVirtualMachineWithCode("[ap] = [ap + 1] * [fp];")
+	t.Run("division", func(t *testing.T) {
+		vm := defaultVirtualMachineWithCode("[ap] = [ap + 1] * [fp];")
 		setInitialReg(vm, 3, 1, 0)
 
 		writeToDataSegment(vm, vm.Context.Fp, 2)
 		writeToDataSegment(vm, vm.Context.Ap, 10)
 
-		err:= vm.RunStep(&hintrunner)
+		err := vm.RunStep(&hintrunner)
 		require.NoError(t, err)
 
 		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Ap+1)
@@ -959,7 +959,6 @@ func TestAssertEqualInstruction(t *testing.T) {
 	})
 
 }
-
 
 // ======================
 // Test Memory Relocation


### PR DESCRIPTION
A test for an  instruction that checks if two values are equal. It is represented by the following syntax:
`<left_hand_op> = <right_hand_op>`
It ensures that both sides are equal and rejects the program execution otherwise.
For example: 
` [reg0 + offop0] ◦ imm`

where  `◦`  is an arithmetic operator (addition or multiplication), and `imm` is any fixed field element. 
Division and subtraction are represented as multiplication and addition (respectively) with a different order of operands.
Issue #118 