### PR TITLE
Test for unconditional jump instructions

### DIFF
--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -960,6 +960,48 @@ func TestAssertEqualInstruction(t *testing.T) {
 
 }
 
+// add test for each different form of jump instructions
+func TestJumpInstructions(t *testing.T) {
+
+	// relative jumps
+	t.Run("jmp rel 5", func(t *testing.T){
+		vm := defaultVirtualMachine()
+
+		vm.Context.Pc = mem.MemoryAddress{SegmentIndex: 1, Offset: 4}
+		relAddr := uint64(5)
+		res := mem.MemoryValueFromInt(relAddr)
+
+		instruction := a.Instruction{
+			PcUpdate: a.PcUpdateJumpRel,
+		}
+		nextPc, err := vm.updatePc(&instruction, nil, nil, &res)
+
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryAddress{SegmentIndex: 1, Offset: 9}, nextPc)
+
+	})
+
+	// absolute jumps
+	t.Run("jmp abs 123", func(t *testing.T) {
+		vm := defaultVirtualMachine()
+
+		vm.Context.Pc = mem.MemoryAddress{SegmentIndex: 0, Offset: 3}
+		jmpAddr := uint64(123)
+		res := mem.MemoryValueFromSegmentAndOffset(0, jmpAddr)
+
+		instruction := a.Instruction{
+			PcUpdate: a.PcUpdateJump,
+		}
+		nextPc, err := vm.updatePc(&instruction, nil, nil, &res)
+
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryAddress{SegmentIndex: 0, Offset: jmpAddr}, nextPc)
+
+	})
+
+}
+
+
 // ======================
 // Test Memory Relocation
 // ======================

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -927,6 +927,78 @@ func TestAssertEqualInstruction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, mem.MemoryValueFromInt(-5), mv)
 	})
+
+	t.Run("multiply", func(t *testing.T){
+		vm:= defaultVirtualMachineWithCode("[ap] = [ap - 1] * [fp];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Fp, 5)
+		writeToDataSegment(vm, vm.Context.Ap-1, 10)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Ap)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(50), mv)
+	})
+
+	t.Run("comparison equality", func(t *testing.T){
+		vm:= defaultVirtualMachineWithCode("[ap + 1] = [fp];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Ap+1, 5)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(5), mv)
+	})
+
+	t.Run("comparison equality 2", func(t *testing.T){
+		vm:= defaultVirtualMachineWithCode("[ap - 1] = [fp];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Ap-1, 7)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(7), mv)
+	})
+
+	t.Run("compare register values", func(t *testing.T){
+		vm:=defaultVirtualMachineWithCode("[ap] = [fp];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Ap, 3)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(3), mv)
+	})
+
+	t.Run("compare register values left to right", func(t *testing.T){
+		vm:=defaultVirtualMachineWithCode("[fp] = [ap - 1];")
+		setInitialReg(vm, 3, 1, 0)
+
+		writeToDataSegment(vm, vm.Context.Ap-1, 10)
+
+		err:= vm.RunStep(&hintrunner)
+		require.NoError(t, err)
+
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		require.NoError(t, err)
+		assert.Equal(t, mem.MemoryValueFromInt(10), mv)
+	})
+
 }
 
 // ======================

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -964,10 +964,10 @@ func TestAssertEqualInstruction(t *testing.T) {
 func TestJumpInstructions(t *testing.T) {
 
 	// relative jumps
-	t.Run("jmp rel", func(t *testing.T){
+	t.Run("jmp rel", func(t *testing.T) {
 		vm := defaultVirtualMachineWithCode("jmp rel [ap + 1] + [ap - 7];")
 
-		vm.Context.Pc = mem.MemoryAddress{SegmentIndex: 1, Offset: 3}
+		vm.Context.Pc = mem.MemoryAddress{SegmentIndex: 0, Offset: 3}
 		relAddr := uint64(10)
 		res := mem.MemoryValueFromInt(relAddr)
 
@@ -1000,7 +1000,6 @@ func TestJumpInstructions(t *testing.T) {
 	})
 
 }
-
 
 // ======================
 // Test Memory Relocation

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -964,11 +964,11 @@ func TestAssertEqualInstruction(t *testing.T) {
 func TestJumpInstructions(t *testing.T) {
 
 	// relative jumps
-	t.Run("jmp rel 5", func(t *testing.T){
-		vm := defaultVirtualMachine()
+	t.Run("jmp rel", func(t *testing.T){
+		vm := defaultVirtualMachineWithCode("jmp rel [ap + 1] + [ap - 7];")
 
-		vm.Context.Pc = mem.MemoryAddress{SegmentIndex: 1, Offset: 4}
-		relAddr := uint64(5)
+		vm.Context.Pc = mem.MemoryAddress{SegmentIndex: 1, Offset: 3}
+		relAddr := uint64(10)
 		res := mem.MemoryValueFromInt(relAddr)
 
 		instruction := a.Instruction{
@@ -977,13 +977,13 @@ func TestJumpInstructions(t *testing.T) {
 		nextPc, err := vm.updatePc(&instruction, nil, nil, &res)
 
 		require.NoError(t, err)
-		assert.Equal(t, mem.MemoryAddress{SegmentIndex: 1, Offset: 9}, nextPc)
+		assert.Equal(t, mem.MemoryAddress{SegmentIndex: 1, Offset: 3 + relAddr}, nextPc)
 
 	})
 
 	// absolute jumps
 	t.Run("jmp abs 123", func(t *testing.T) {
-		vm := defaultVirtualMachine()
+		vm := defaultVirtualMachineWithCode("jmp abs 123;")
 
 		vm.Context.Pc = mem.MemoryAddress{SegmentIndex: 0, Offset: 3}
 		jmpAddr := uint64(123)

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -943,63 +943,23 @@ func TestAssertEqualInstruction(t *testing.T) {
 		assert.Equal(t, mem.MemoryValueFromInt(50), mv)
 	})
 
-	t.Run("comparison equality", func(t *testing.T){
-		vm:= defaultVirtualMachineWithCode("[ap + 1] = [fp];")
+	t.Run("division", func(t *testing.T){
+		vm:= defaultVirtualMachineWithCode("[ap] = [ap + 1] * [fp];")
 		setInitialReg(vm, 3, 1, 0)
 
-		writeToDataSegment(vm, vm.Context.Ap+1, 5)
+		writeToDataSegment(vm, vm.Context.Fp, 2)
+		writeToDataSegment(vm, vm.Context.Ap, 10)
 
 		err:= vm.RunStep(&hintrunner)
 		require.NoError(t, err)
 
-		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
+		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Ap+1)
 		require.NoError(t, err)
 		assert.Equal(t, mem.MemoryValueFromInt(5), mv)
 	})
 
-	t.Run("comparison equality 2", func(t *testing.T){
-		vm:= defaultVirtualMachineWithCode("[ap - 1] = [fp];")
-		setInitialReg(vm, 3, 1, 0)
-
-		writeToDataSegment(vm, vm.Context.Ap-1, 7)
-
-		err:= vm.RunStep(&hintrunner)
-		require.NoError(t, err)
-
-		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
-		require.NoError(t, err)
-		assert.Equal(t, mem.MemoryValueFromInt(7), mv)
-	})
-
-	t.Run("compare register values", func(t *testing.T){
-		vm:=defaultVirtualMachineWithCode("[ap] = [fp];")
-		setInitialReg(vm, 3, 1, 0)
-
-		writeToDataSegment(vm, vm.Context.Ap, 3)
-
-		err:= vm.RunStep(&hintrunner)
-		require.NoError(t, err)
-
-		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
-		require.NoError(t, err)
-		assert.Equal(t, mem.MemoryValueFromInt(3), mv)
-	})
-
-	t.Run("compare register values left to right", func(t *testing.T){
-		vm:=defaultVirtualMachineWithCode("[fp] = [ap - 1];")
-		setInitialReg(vm, 3, 1, 0)
-
-		writeToDataSegment(vm, vm.Context.Ap-1, 10)
-
-		err:= vm.RunStep(&hintrunner)
-		require.NoError(t, err)
-
-		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Fp)
-		require.NoError(t, err)
-		assert.Equal(t, mem.MemoryValueFromInt(10), mv)
-	})
-
 }
+
 
 // ======================
 // Test Memory Relocation

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -928,14 +928,14 @@ func TestAssertEqualInstruction(t *testing.T) {
 		assert.Equal(t, mem.MemoryValueFromInt(-5), mv)
 	})
 
-	t.Run("multiply", func(t *testing.T){
-		vm:= defaultVirtualMachineWithCode("[ap] = [ap - 1] * [fp];")
+	t.Run("multiplication", func(t *testing.T) {
+		vm := defaultVirtualMachineWithCode("[ap] = [ap - 1] * [fp];")
 		setInitialReg(vm, 3, 1, 0)
 
 		writeToDataSegment(vm, vm.Context.Fp, 5)
 		writeToDataSegment(vm, vm.Context.Ap-1, 10)
 
-		err:= vm.RunStep(&hintrunner)
+		err := vm.RunStep(&hintrunner)
 		require.NoError(t, err)
 
 		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Ap)
@@ -943,14 +943,14 @@ func TestAssertEqualInstruction(t *testing.T) {
 		assert.Equal(t, mem.MemoryValueFromInt(50), mv)
 	})
 
-	t.Run("division", func(t *testing.T){
-		vm:= defaultVirtualMachineWithCode("[ap] = [ap + 1] * [fp];")
+	t.Run("division", func(t *testing.T) {
+		vm := defaultVirtualMachineWithCode("[ap] = [ap + 1] * [fp];")
 		setInitialReg(vm, 3, 1, 0)
 
 		writeToDataSegment(vm, vm.Context.Fp, 2)
 		writeToDataSegment(vm, vm.Context.Ap, 10)
 
-		err:= vm.RunStep(&hintrunner)
+		err := vm.RunStep(&hintrunner)
 		require.NoError(t, err)
 
 		mv, err := vm.Memory.Read(ExecutionSegment, vm.Context.Ap+1)
@@ -959,7 +959,6 @@ func TestAssertEqualInstruction(t *testing.T) {
 	})
 
 }
-
 
 // ======================
 // Test Memory Relocation


### PR DESCRIPTION
Tests for relative jumps (where the operand represents an offset
from the current pc) and absolute jumps – represented by the keywords `rel`
and `abs`, respectively

Unconditional jumps:
```
jmp abs <address>
jmp rel <offset>
```
#117 