### PR TITLE
Builtin keccak

### DIFF
--- a/pkg/vm/builtins/keccak.go
+++ b/pkg/vm/builtins/keccak.go
@@ -13,6 +13,14 @@ const (
 	BYTES_IN_U64_WORD         = 8
 )
 
+type uint128 struct {
+	High, Low uint64
+}
+
+type U256 struct {
+	High, Low uint128
+}
+
 // u128ToU64 converts a big.Int (representing a 128-bit integer) to a uint64,
 // assuming the big.Int fits into a uint64.
 func U128ToU64(input *big.Int) (uint64, error) {
@@ -36,6 +44,20 @@ func U128Split(input *big.Int) (high, low uint64, err error) {
 		return 0, 0, err
 	}
 	return high, low, nil
+}
+
+// SplitU256 splits a U256 into four uint64s.
+func SplitU256(value U256) (lowLow, lowHigh, highLow, highHigh uint64) {
+	lowLow, lowHigh = value.Low.Low, value.Low.High
+	highLow, highHigh = value.High.Low, value.High.High
+	return
+}
+
+// AppendU256ToSlice appends the values from a U256 to a slice in the specified order.
+func AppendU256ToSlice(slice []uint64, value U256) []uint64 {
+	lowLow, lowHigh, highLow, highHigh := SplitU256(value)
+	slice = append(slice, lowLow, lowHigh, highLow, highHigh)
+	return slice
 }
 
 // Keccak256 computes the Keccak-256 hash of the input data.

--- a/pkg/vm/builtins/keccak.go
+++ b/pkg/vm/builtins/keccak.go
@@ -1,0 +1,26 @@
+package builtins
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/sha3"
+)
+
+// Keccak256 computes the Keccak-256 hash of the input data.
+func Keccak256(data []byte) ([]byte, error) {
+	hasher := sha3.NewLegacyKeccak256()
+	if _, err := hasher.Write(data); err != nil {
+		return nil, err // Return the error to the caller.
+	}
+	return hasher.Sum(nil), nil // Return the hash and a nil error.
+}
+
+// Cairo_Keccak computes and prints the Keccak-256 hash of the input data.
+func Cairo_Keccak(data []byte) {
+	hash, err := Keccak256(data)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	fmt.Printf("%x\n", hash)
+}

--- a/pkg/vm/builtins/keccak.go
+++ b/pkg/vm/builtins/keccak.go
@@ -86,7 +86,7 @@ func AddPadding(input []uint64, lastInputWord uint64, lastInputNumBytes int) ([]
 		firstWordToAppend = firstPaddingBytePart + r
 	}
 
-	// Debug print statements:
+	//	// Debug print statements:
 	fmt.Printf("firstPaddingBytePart: %x\n", firstPaddingBytePart)
 	fmt.Printf("r: %x\n", r)
 	fmt.Printf("firstWordToAppend: %x\n", firstWordToAppend)
@@ -108,6 +108,7 @@ func AddPadding(input []uint64, lastInputWord uint64, lastInputNumBytes int) ([]
 		}
 		return input
 	}
+	//Debug when error
 	fmt.Println("Before finalizePadding:", input)
 	input = finalizePadding(input, uint32(KECCAK_FULL_RATE_IN_U64S-1-lastBlockNumFullWords))
 	fmt.Println("After finalizePadding:", input)

--- a/pkg/vm/builtins/keccak.go
+++ b/pkg/vm/builtins/keccak.go
@@ -89,17 +89,23 @@ func Keccak256(data []byte) ([]byte, error) {
 	return hasher.Sum(nil), nil // Return the hash and a nil error.
 }
 
+// ConvertToByteData converts a slice of uint64 to a slice of byte.
+func ConvertToByteData(input []uint64) []byte {
+	byteData := make([]byte, len(input)*8) // 8 bytes per uint64
+	for i, word := range input {
+		binary.LittleEndian.PutUint64(byteData[i*8:], word)
+	}
+	return byteData
+}
+
 func CairoKeccak(input []uint64, lastInputWord uint64, lastInputNumBytes int) ([]byte, error) {
 	input, err := AddPadding(input, lastInputWord, lastInputNumBytes)
 	if err != nil {
 		return nil, err // handle error
 	}
-	// Convert the input slice of uint64 to a slice of byte.
-	byteData := make([]byte, len(input)*8) // 8 bytes per uint64
-	for i, word := range input {
-		binary.LittleEndian.PutUint64(byteData[i*8:], word)
-	}
-	fmt.Println(byteData)
+
+	// Use ConvertToByteData to get byteData.
+	byteData := ConvertToByteData(input)
 
 	// Use your existing Keccak256 function.
 	return Keccak256(byteData)

--- a/pkg/vm/builtins/keccak.go
+++ b/pkg/vm/builtins/keccak.go
@@ -24,23 +24,123 @@ func U128Split(input *uint256.Int) (high, low uint64) {
 	return
 }
 
+// Keccak256 computes the Keccak-256 hash of the input data.
+func Keccak256(data []byte) ([]byte, error) {
+	hasher := sha3.NewLegacyKeccak256()
+	if _, err := hasher.Write(data); err != nil {
+		return nil, err // Return the error to the caller.
+	}
+	return hasher.Sum(nil), nil // Return the hash and a nil error.
+}
+
+// ConvertToByteData converts a slice of uint64 to a slice of byte.
+func ConvertToByteData(input []uint64) []byte {
+	byteData := make([]byte, len(input)*8) // 8 bytes per uint64
+	for i, word := range input {
+		binary.LittleEndian.PutUint64(byteData[i*8:], word)
+	}
+	return byteData
+}
+
+func CairoKeccak(input []uint64, lastInputWord uint64, lastInputNumBytes int) ([]byte, error) {
+	paddedInput, err := AddPadding(input, lastInputWord, lastInputNumBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return Keccak256(ConvertToByteData(paddedInput))
+}
+
+func AddPadding(input []uint64, lastInputWord uint64, lastInputNumBytes int) ([]uint64, error) {
+	fmt.Printf("input before AddPadding conversion in addpadding: %x\n ", input)
+	wordsDivisor := KECCAK_FULL_RATE_IN_U64S
+	lastBlockNumFullWords := len(input) % wordsDivisor
+
+	var firstWordToAppend, firstPaddingBytePart, r uint64
+	if lastInputNumBytes == 0 {
+		firstWordToAppend = 1
+	} else {
+		switch lastInputNumBytes {
+		case 1:
+			firstPaddingBytePart = 0x100
+		case 2:
+			firstPaddingBytePart = 0x10000
+		case 3:
+			firstPaddingBytePart = 0x1000000
+		case 4:
+			firstPaddingBytePart = 0x100000000
+		case 5:
+			firstPaddingBytePart = 0x10000000000
+		case 6:
+			firstPaddingBytePart = 0x1000000000000
+		case 7:
+			firstPaddingBytePart = 0x100000000000000
+		default:
+			return nil, fmt.Errorf("keccak last input word >7b")
+		}
+		r = lastInputWord % firstPaddingBytePart
+		firstWordToAppend = firstPaddingBytePart + r
+	}
+
+	//	// Debug print statements:
+	fmt.Printf("firstPaddingBytePart: %x\n", firstPaddingBytePart)
+	fmt.Printf("r: %x\n", r)
+	fmt.Printf("firstWordToAppend: %x\n", firstWordToAppend)
+
+	inputAfterPadding := append(input, firstWordToAppend)
+
+	if lastBlockNumFullWords == KECCAK_FULL_RATE_IN_U64S-1 {
+		inputAfterPadding = append(inputAfterPadding, 0x8000000000000000+firstWordToAppend)
+		return inputAfterPadding, nil
+	}
+
+	//Debug when error
+	fmt.Println("Before finalizePadding:", inputAfterPadding)
+	finalizedPadding := finalizePadding(inputAfterPadding, uint32(KECCAK_FULL_RATE_IN_U64S-1-lastBlockNumFullWords))
+	fmt.Println("After finalizePadding:", finalizedPadding)
+
+	return finalizedPadding, nil
+}
+
+func finalizePadding(input []uint64, numPaddingWords uint32) []uint64 {
+	for i := uint32(0); i < numPaddingWords; i++ {
+		if i == numPaddingWords-1 {
+			input = append(input, 0x8000000000000000)
+		} else {
+			input = append(input, 0)
+		}
+	}
+	return input
+}
+
+//Little Endian way for Keccak256
+
 // KeccakAddU256LE appends the low and high 64-bit words of a U256 value to a keccak input.
 func KeccakAddU256LE(keccakInput []uint64, value *uint256.Int) []uint64 {
 	valueCopy := new(uint256.Int).Set(value)
-	// Split the low 128 bits into two uint64s and append them to keccakInput.
+	// Split the "low" 128 bits into two uint64s and append them to keccakInput.
 	low, high := U128Split(valueCopy)
 	keccakInput = append(keccakInput, low, high)
 
 	// Shift the value right by 128 bits to get the high 128 bits.
-	value.Rsh(value, 128)
-	// Split the high 128 bits into two uint64s and append them to keccakInput.
-	low, high = U128Split(value)
+	valueCopy.Rsh(valueCopy, 128)
+
+	// Split the "high" 128 bits into two uint64s and append them to keccakInput.
+	low, high = U128Split(valueCopy)
 	keccakInput = append(keccakInput, low, high)
 
 	return keccakInput
 }
 
-//Starting BE codes
+func KeccakU256sLEInputs(inputs []*uint256.Int) ([]byte, error) {
+	var keccakInput []uint64
+	for _, value := range inputs {
+		keccakInput = KeccakAddU256LE(keccakInput, value)
+	}
+	return CairoKeccak(keccakInput, 0, 0)
+}
+
+//Big Endian way codes
 
 func ReverseBytes128(value *uint256.Int) *uint256.Int {
 	byteSlice := value.Bytes()
@@ -76,96 +176,4 @@ func KeccakU256sBEInputs(inputs []*uint256.Int) ([]byte, error) {
 		keccakInput = KeccakAddU256BE(keccakInput, value)
 	}
 	return CairoKeccak(keccakInput, 0, 0)
-}
-
-// END of BE codes
-
-// Keccak256 computes the Keccak-256 hash of the input data.
-func Keccak256(data []byte) ([]byte, error) {
-	hasher := sha3.NewLegacyKeccak256()
-	if _, err := hasher.Write(data); err != nil {
-		return nil, err // Return the error to the caller.
-	}
-	return hasher.Sum(nil), nil // Return the hash and a nil error.
-}
-
-// ConvertToByteData converts a slice of uint64 to a slice of byte.
-func ConvertToByteData(input []uint64) []byte {
-	byteData := make([]byte, len(input)*8) // 8 bytes per uint64
-	for i, word := range input {
-		binary.LittleEndian.PutUint64(byteData[i*8:], word)
-	}
-	return byteData
-}
-
-func CairoKeccak(input []uint64, lastInputWord uint64, lastInputNumBytes int) ([]byte, error) {
-	input, err := AddPadding(input, lastInputWord, lastInputNumBytes)
-	if err != nil {
-		return nil, err // handle error
-	}
-
-	// Use ConvertToByteData to get byteData.
-	byteData := ConvertToByteData(input)
-
-	// Use your existing Keccak256 function.
-	return Keccak256(byteData)
-}
-
-func AddPadding(input []uint64, lastInputWord uint64, lastInputNumBytes int) ([]uint64, error) {
-	wordsDivisor := KECCAK_FULL_RATE_IN_U64S
-	lastBlockNumFullWords := len(input) % wordsDivisor
-
-	var firstWordToAppend, firstPaddingBytePart, r uint64
-	if lastInputNumBytes == 0 {
-		firstWordToAppend = 1
-	} else {
-		switch lastInputNumBytes {
-		case 1:
-			firstPaddingBytePart = 0x100
-		case 2:
-			firstPaddingBytePart = 0x10000
-		case 3:
-			firstPaddingBytePart = 0x1000000
-		case 4:
-			firstPaddingBytePart = 0x100000000
-		case 5:
-			firstPaddingBytePart = 0x10000000000
-		case 6:
-			firstPaddingBytePart = 0x1000000000000
-		case 7:
-			firstPaddingBytePart = 0x100000000000000
-		default:
-			return nil, fmt.Errorf("keccak last input word >7b")
-		}
-		r = lastInputWord % firstPaddingBytePart
-		firstWordToAppend = firstPaddingBytePart + r
-	}
-
-	//	// Debug print statements:
-	fmt.Printf("firstPaddingBytePart: %x\n", firstPaddingBytePart)
-	fmt.Printf("r: %x\n", r)
-	fmt.Printf("firstWordToAppend: %x\n", firstWordToAppend)
-
-	input = append(input, firstWordToAppend) // Moved outside the if-else block
-
-	if lastBlockNumFullWords == KECCAK_FULL_RATE_IN_U64S-1 {
-		input = append(input, 0x8000000000000000+firstWordToAppend)
-		return input, nil
-	}
-
-	finalizePadding := func(input []uint64, numPaddingWords uint32) []uint64 {
-		for i := uint32(0); i < numPaddingWords; i++ {
-			if i == numPaddingWords-1 {
-				input = append(input, 0x8000000000000000)
-			} else {
-				input = append(input, 0)
-			}
-		}
-		return input
-	}
-	//Debug when error
-	fmt.Println("Before finalizePadding:", input)
-	input = finalizePadding(input, uint32(KECCAK_FULL_RATE_IN_U64S-1-lastBlockNumFullWords))
-	fmt.Println("After finalizePadding:", input)
-	return input, nil
 }

--- a/pkg/vm/builtins/keccak.go
+++ b/pkg/vm/builtins/keccak.go
@@ -2,9 +2,35 @@ package builtins
 
 import (
 	"fmt"
+	"math/big"
 
 	"golang.org/x/crypto/sha3"
 )
+
+// u128ToU64 converts a big.Int (representing a 128-bit integer) to a uint64,
+// assuming the big.Int fits into a uint64.
+func U128ToU64(input *big.Int) (uint64, error) {
+	if input.BitLen() > 64 {
+		return 0, fmt.Errorf("value too large to fit in uint64")
+	}
+	return input.Uint64(), nil
+}
+
+// u128Split splits a big.Int (representing a 128-bit integer) into two uint64s.
+func U128Split(input *big.Int) (high, low uint64, err error) {
+	divisor := new(big.Int)
+	divisor.SetString("10000000000000000", 16) // Set the divisor using a hexadecimal string
+	quotient, remainder := new(big.Int).DivMod(input, divisor, new(big.Int))
+	high, err = U128ToU64(quotient)
+	if err != nil {
+		return 0, 0, err
+	}
+	low, err = U128ToU64(remainder)
+	if err != nil {
+		return 0, 0, err
+	}
+	return high, low, nil
+}
 
 // Keccak256 computes the Keccak-256 hash of the input data.
 func Keccak256(data []byte) ([]byte, error) {

--- a/pkg/vm/builtins/keccak_exercise.py
+++ b/pkg/vm/builtins/keccak_exercise.py
@@ -1,0 +1,7 @@
+# Given values
+high = 280360676274067731044963585568268448175
+low = 314240319136055307035435783795864305109
+
+# Calculating the u256 value
+u256_value = (high * (2 ** 128)) + low
+print(u256_value)

--- a/pkg/vm/builtins/keccak_test.go
+++ b/pkg/vm/builtins/keccak_test.go
@@ -14,9 +14,14 @@ import (
 func TestKeccak256(t *testing.T) {
 	// Input data: array of bytes from 1 to 17, similar to the input in the Rust test.
 	input := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}
+	hexStr := hex.EncodeToString(input)
+	fmt.Println("the hex Str is: ", hexStr)
+	//0102030405060708090a0b0c0d0e0f1011
 
 	// Known correct Keccak-256 hash value for the input data, obtained from an online calculator. https://emn178.github.io/online-tools/keccak_256.html
 	expectedHash := "57e46e893805ca9503660cd6ef2b39e24750a502ed7c71270f214dcb114b7113"
+	expectedHashByteData, err := hex.DecodeString(expectedHash)
+	fmt.Println("the expectedHash to byte is: ", expectedHashByteData, err)
 
 	// Call the Keccak256 function.
 	hash, err := Keccak256(input)
@@ -24,9 +29,20 @@ func TestKeccak256(t *testing.T) {
 
 	// Convert the obtained hash to a hex string.
 	hashHex := hex.EncodeToString(hash)
+	fmt.Println("the hash is: ", hash)
 
 	// Compare the obtained hash with the expected hash.
 	assert.Equal(t, expectedHash, hashHex, "Expected %s, got %s", expectedHash, hashHex)
+
+	// for keccak result : https://emn178.github.io/online-tools/keccak_256.html?input_type=hex&input=0102030405060708090a0b0c0d0e0f1011
+	// which is
+	//57e46e893805ca9503660cd6ef2b39e24750a502ed7c71270f214dcb114b7113
+	// for sha3 result : https://emn178.github.io/online-tools/sha3_256.html?input_type=hex&input=0102030405060708090a0b0c0d0e0f1011
+	// which is
+	//5ea232134fe405605b468996dd5d77e7cdf6b63be625826d4f27c302ab17d65a
+	//Rust output is : d2eb808dfba4703c528d145dfe6571afec687be9c50d2218388da73622e8fdd5
+	//D2EB808DFBA4703C528D145DFE6571AFEC687BE9C50D2218388DA73622E8FDD5
+
 }
 
 func TestU128Split(t *testing.T) {
@@ -73,6 +89,35 @@ func TestAddPaddingPlainCase(t *testing.T) {
 			expected:          []uint64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x8000000000000000},
 		},
 		{
+			input: []uint64{
+				0x0000000000000001,
+				0x0000000000000000,
+				0x0000000000000000,
+				0x0000000000000000,
+			},
+			lastInputWord:     0,
+			lastInputNumBytes: 0,
+			expected: []uint64{
+				0x0000000000000001, // 1st
+				0x0000000000000000, // 2nd
+				0x0000000000000000, // 3rd
+				0x0000000000000000, // 4th
+				0x0000000000000001, // 5th
+				0x0000000000000000, // 6th
+				0x0000000000000000, // 7th
+				0x0000000000000000, // 8th
+				0x0000000000000000, // 9th
+				0x0000000000000000, // 10th
+				0x0000000000000000, // 11th
+				0x0000000000000000, // 12th
+				0x0000000000000000, // 13th
+				0x0000000000000000, // 14th
+				0x0000000000000000, // 15th
+				0x0000000000000000, // 16th
+				0x8000000000000000, // 17th
+			},
+		},
+		{
 			input:             []uint64{0x1234567890abcdef},
 			lastInputWord:     0,
 			lastInputNumBytes: 0,
@@ -112,7 +157,7 @@ func TestAddPaddingOperandCase(t *testing.T) {
 	}
 }
 
-func TestKeccakU64(t *testing.T) {
+func TestCairoKeccakU64(t *testing.T) {
 	tests := []struct {
 		name              string
 		input             []uint64
@@ -150,3 +195,14 @@ func TestKeccakU64(t *testing.T) {
 		})
 	}
 }
+
+// [
+// 	1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0   // 1
+// 	0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0   // 2
+// 	0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0   // 3
+// 	0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0   // 4
+// 	0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0   // 5
+// 	0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0   // 6
+// 	0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0   // 7
+// 	0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 128 // 8
+// ]

--- a/pkg/vm/builtins/keccak_test.go
+++ b/pkg/vm/builtins/keccak_test.go
@@ -34,6 +34,7 @@ func TestKeccak256(t *testing.T) {
 	// Compare the obtained hash with the expected hash.
 	assert.Equal(t, expectedHash, hashHex, "Expected %s, got %s", expectedHash, hashHex)
 
+	//jake : below is for debugging. to be deleted afterwards
 	// for keccak result : https://emn178.github.io/online-tools/keccak_256.html?input_type=hex&input=0102030405060708090a0b0c0d0e0f1011
 	// which is
 	//57e46e893805ca9503660cd6ef2b39e24750a502ed7c71270f214dcb114b7113
@@ -42,6 +43,31 @@ func TestKeccak256(t *testing.T) {
 	//5ea232134fe405605b468996dd5d77e7cdf6b63be625826d4f27c302ab17d65a
 	//Rust output is : d2eb808dfba4703c528d145dfe6571afec687be9c50d2218388da73622e8fdd5
 	//D2EB808DFBA4703C528D145DFE6571AFEC687BE9C50D2218388DA73622E8FDD5
+
+}
+
+func TestKeccak256_2(t *testing.T) {
+	// Input data: array of bytes from 1 to 17, similar to the input in the Rust test.
+	input := []byte{1, 0, 0, 0}
+	hexStr := hex.EncodeToString(input)
+	fmt.Println("the hex Str is: ", hexStr)
+	//01000000
+
+	// Known correct Keccak-256 hash value for the input data, obtained from an online calculator. https://emn178.github.io/online-tools/keccak_256.html
+	expectedHash := "e37890bf230cf36ea140a5dbb9a561aa7ef84f8f995873db8386eba4a95c7bbe"
+	expectedHashByteData, err := hex.DecodeString(expectedHash)
+	fmt.Println("the expectedHash to byte is: ", expectedHashByteData, err)
+
+	// Call the Keccak256 function.
+	hash, err := Keccak256(input)
+	require.NoError(t, err) // Ensure no error is returned.
+
+	// Convert the obtained hash to a hex string.
+	hashHex := hex.EncodeToString(hash)
+	fmt.Println("the hash is: ", hash)
+
+	// Compare the obtained hash with the expected hash.
+	assert.Equal(t, expectedHash, hashHex, "Expected %s, got %s", expectedHash, hashHex)
 
 }
 
@@ -157,27 +183,20 @@ func TestAddPaddingOperandCase(t *testing.T) {
 	}
 }
 
-func TestCairoKeccakU64(t *testing.T) {
+func TestCairoKeccak(t *testing.T) {
 	tests := []struct {
 		name              string
 		input             []uint64
 		lastInputWord     uint64
 		lastInputNumBytes int
-		expectedLow       string
-		expectedHigh      string
+		expectedHash      string
 	}{
 		{
-			name: "Test case 1 from Rust",
-			input: []uint64{
-				0x0000000000000001,
-				0x0000000000000000,
-				0x0000000000000000,
-				0x0000000000000000,
-			},
+			name:              "Test case 1",
+			input:             []uint64{1, 0, 0, 0},
 			lastInputWord:     0,
 			lastInputNumBytes: 0,
-			expectedLow:       "0x587f7cc3722e9654ea3963d5fe8c0748",
-			expectedHigh:      "0xa5963aa610cb75ba273817bce5f8c48f",
+			expectedHash:      "a80c226a0612d2578acff9caeb00583cb8002ccfb5f442d47ec6838f35d72b2c",
 		},
 	}
 
@@ -186,12 +205,11 @@ func TestCairoKeccakU64(t *testing.T) {
 			res, err := CairoKeccak(tt.input, tt.lastInputWord, tt.lastInputNumBytes)
 			require.NoError(t, err)
 
-			// Assuming res is a []byte that represents a 256-bit number,
-			// split it into two 128-bit numbers represented as strings.
-			low := fmt.Sprintf("%x", res[:16])
-			high := fmt.Sprintf("%x", res[16:])
-			require.Equal(t, tt.expectedLow, low)
-			require.Equal(t, tt.expectedHigh, high)
+			hashHex := hex.EncodeToString(res)
+			fmt.Println("the hash is: ", hashHex)
+
+			// Compare the obtained hash with the expected hash.
+			assert.Equal(t, tt.expectedHash, hashHex, "Expected %s, got %s", tt.expectedHash, hashHex)
 		})
 	}
 }
@@ -206,3 +224,20 @@ func TestCairoKeccakU64(t *testing.T) {
 // 	0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0   // 7
 // 	0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 128 // 8
 // ]
+
+// 01000000000000000 //1, has 1
+// 00000000000000000 //2
+// 00000000000000000 //3
+// 00000000000000100 //4, has 1
+// 00000000000000000 //5
+// 00000000000000000 //6
+// 00000000000000000 //7
+// 00000000000000000 //8
+// 00000000000000000 //9
+// 00000000000000000 //10
+// 00000000000000000 //11
+// 00000000000000000 //12
+// 00000000000000000 //13
+// 00000000000000000 //14
+// 00000000000000000 //15
+// 00000000000000080 //16 , has 1

--- a/pkg/vm/builtins/keccak_test.go
+++ b/pkg/vm/builtins/keccak_test.go
@@ -1,0 +1,27 @@
+package builtins
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeccak256(t *testing.T) {
+	// Input data: array of bytes from 1 to 17, similar to the input in the Rust test.
+	input := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}
+
+	// Known correct Keccak-256 hash value for the input data, obtained from an online calculator. https://emn178.github.io/online-tools/keccak_256.html
+	expectedHash := "57e46e893805ca9503660cd6ef2b39e24750a502ed7c71270f214dcb114b7113"
+
+	// Call the Keccak256 function.
+	hash, err := Keccak256(input)
+	require.NoError(t, err) // Ensure no error is returned.
+
+	// Convert the obtained hash to a hex string.
+	hashHex := hex.EncodeToString(hash)
+
+	// Compare the obtained hash with the expected hash.
+	assert.Equal(t, expectedHash, hashHex, "Expected %s, got %s", expectedHash, hashHex)
+}

--- a/pkg/vm/builtins/keccak_test.go
+++ b/pkg/vm/builtins/keccak_test.go
@@ -60,8 +60,8 @@ func TestU128Split(t *testing.T) {
 	}{
 		{
 			input:        "00000001000000020000000300000004",
-			expectedHigh: 4294967298,
-			expectedLow:  12884901892,
+			expectedHigh: 0x0000000100000002,
+			expectedLow:  0x0000000300000004,
 			expectedErr:  false,
 		},
 	}
@@ -75,6 +75,60 @@ func TestU128Split(t *testing.T) {
 		}
 		if high != test.expectedHigh || low != test.expectedLow {
 			t.Errorf("expected (%d, %d), got (%d, %d) for input %s", test.expectedHigh, test.expectedLow, high, low, test.input)
+		}
+	}
+}
+
+func TestAddPaddingPlainCase(t *testing.T) {
+	// Define your test cases as a table
+	testCases := []struct {
+		input             []uint64
+		lastInputWord     uint64
+		lastInputNumBytes int
+		expected          []uint64
+	}{
+		{
+			input:             []uint64{},
+			lastInputWord:     0,
+			lastInputNumBytes: 0,
+			expected:          []uint64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x8000000000000000},
+		},
+		{
+			input:             []uint64{0x1234567890abcdef},
+			lastInputWord:     0,
+			lastInputNumBytes: 0,
+			expected:          []uint64{0x1234567890abcdef, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x8000000000000000},
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, err := AddPadding(testCase.input, testCase.lastInputWord, testCase.lastInputNumBytes)
+		if assert.NoError(t, err) {
+			assert.Equal(t, testCase.expected, result)
+		}
+	}
+}
+
+func TestAddPaddingOperandCase(t *testing.T) {
+	// Define your test cases as a table
+	testCases := []struct {
+		input             []uint64
+		lastInputWord     uint64
+		lastInputNumBytes int
+		expected          []uint64
+	}{
+		{
+			input:             []uint64{0x1234567890abcdef},
+			lastInputWord:     0xabcdef,
+			lastInputNumBytes: 3,
+			expected:          []uint64{0x1234567890abcdef, 0x1000000 + 0xabcdef, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x8000000000000000},
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, err := AddPadding(testCase.input, testCase.lastInputWord, testCase.lastInputNumBytes)
+		if assert.NoError(t, err) {
+			assert.Equal(t, testCase.expected, result)
 		}
 	}
 }

--- a/pkg/vm/builtins/keccak_test.go
+++ b/pkg/vm/builtins/keccak_test.go
@@ -35,7 +35,7 @@ func TestU128ToU64(t *testing.T) {
 	}{
 		{"1234567890", 1234567890, false},
 		{"18446744073709551615", 18446744073709551615, false}, // Maximum uint64 value
-		{"18446744073709551616", 0, true},                     // Just over uint64 max
+		{"18446744073709551616", 0, true},                     // Over uint64 max
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Draft PR for Builtin - Keccak256
Done
[x] add padding
[x] applied keccak as CairoKeccak
[x] test result from the web identical (verified)
[x] LE, BE (Little Endian, Big Endian) way of Keccak Created as Rust VM does
[ ] test for LE, BE Keccak

Side Note : in the Cairo Repo, there's "starknet_keccak" in Rust code. Basically doing the same thing. location : https://github.com/cairo/crates/cairo-lang-starknet/src/contract.rs 