### PR TITLE
pkg/assembler: allow JNZ with ap_change

### DIFF
--- a/pkg/assembler/instruction.go
+++ b/pkg/assembler/instruction.go
@@ -332,13 +332,15 @@ func decodeInstructionFlags(instruction *Instruction, flags uint16) error {
 	}
 	instruction.Opcode = Opcode(opcode)
 
-	// for pc udpate Jnz, res should be unconstrainded, no opcode, and ap should update with Imm
+	// for pc udpate Jnz, res should be unconstrainded, no opcode;
+	// it used to have an ap update check, but new Cairo1 compiler
+	// emits Jnz with ap_add1 sometimes
+	// See #184
 	if instruction.PcUpdate == PcUpdateJnz &&
 		(instruction.Res != Unconstrained ||
-			instruction.Opcode != OpCodeNop ||
-			instruction.ApUpdate != SameAp) {
+			instruction.Opcode != OpCodeNop) {
 		return fmt.Errorf(
-			"jnz opcode must have unconstrained res logic, no opcode, and no ap change",
+			"jnz opcode must have unconstrained res logic and no opcode",
 		)
 	}
 

--- a/pkg/assembler/instruction_test.go
+++ b/pkg/assembler/instruction_test.go
@@ -214,9 +214,8 @@ func TestInvalidOpcode(t *testing.T) {
 func TestPcUpdateJnzInvalid(t *testing.T) {
 	instructionInvalidRes := new(f.Element).SetBytes([]byte{0x06, 0x27, 0x80, 0x01, 0x80, 0x01, 0x80, 0x00})
 	instructionInvalidOpcode := new(f.Element).SetBytes([]byte{0x16, 0x07, 0x80, 0x01, 0x80, 0x01, 0x80, 0x00})
-	instructionInvalidApUpdate := new(f.Element).SetBytes([]byte{0x06, 0x07, 0x80, 0x01, 0x80, 0x01, 0x80, 0x00})
 
-	expectedError := "jnz opcode must have unconstrained res logic, no opcode, and no ap change"
+	expectedError := "jnz opcode must have unconstrained res logic and no opcode"
 
 	_, err := DecodeInstruction(instructionInvalidRes)
 
@@ -224,11 +223,6 @@ func TestPcUpdateJnzInvalid(t *testing.T) {
 	assert.ErrorContains(t, err, expectedError)
 
 	_, err = DecodeInstruction(instructionInvalidOpcode)
-
-	require.Error(t, err)
-	assert.ErrorContains(t, err, expectedError)
-
-	_, err = DecodeInstruction(instructionInvalidApUpdate)
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, expectedError)


### PR DESCRIPTION
The cairo1 compiler generates jnz with ap++ for some range-check related code. To support this code in our assembler, the ap_change check should be removed.

See the referenced issue for more context.

Fixes #184