### PR TITLE
add AllocSegment Cairo0 hint detection test

### DIFF
--- a/integration_tests/cairo_files/alloc.cairo
+++ b/integration_tests/cairo_files/alloc.cairo
@@ -1,0 +1,18 @@
+// Test the AllocSegmentCode Cairo0 hint recognition.
+
+from starkware.cairo.common.alloc import alloc
+
+struct Pair {
+  a: felt,
+  b: felt,
+}
+
+func main() {
+  alloc_locals;
+
+  let (local p: Pair*) = alloc();
+  assert p.a = 54;
+  assert p.b = 77;
+
+  ret;
+}


### PR DESCRIPTION
The test uses the `alloc()` function that in turn uses the legacy AllocSegment hint.

The #172 makes it possible to use alloc now,
so we can add an integration test for that.