### PR TITLE
pkg/parsers/zero: improve Identifiers typing

### DIFF
--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -64,19 +64,11 @@ func GetParameters(zeroProgram *zero.ZeroProgram, hint zero.Hint, hintPC uint64)
 		if !ok {
 			return nil, nil, fmt.Errorf("missing identifier %s", referenceName)
 		}
-		identifier, ok := rawIdentifier.(map[string]any)
-		if !ok {
-			return nil, nil, fmt.Errorf("wrong structure for identifier")
-		}
 
-		rawReferences, ok := identifier["references"]
-		if !ok {
+		if len(rawIdentifier.References) == 0 {
 			return nil, nil, fmt.Errorf("identifier %s should have at least one reference", referenceName)
 		}
-		references, ok := rawReferences.([]zero.Reference)
-		if !ok {
-			return nil, nil, fmt.Errorf("expected a list of references")
-		}
+		references := rawIdentifier.References
 
 		// Go through the references in reverse order to get the one with biggest pc smaller or equal to the hint pc
 		var reference zero.Reference

--- a/pkg/parsers/zero/zero.go
+++ b/pkg/parsers/zero/zero.go
@@ -2,8 +2,9 @@ package zero
 
 import (
 	"encoding/json"
-	starknetParser "github.com/NethermindEth/cairo-vm-go/pkg/parsers/starknet"
 	"os"
+
+	starknetParser "github.com/NethermindEth/cairo-vm-go/pkg/parsers/starknet"
 )
 
 type FlowTrackingData struct {
@@ -73,10 +74,25 @@ type ZeroProgram struct {
 	Hints            map[string][]Hint        `json:"hints"`
 	CompilerVersion  string                   `json:"version"`
 	MainScope        string                   `json:"main_scope"`
-	Identifiers      map[string]any           `json:"identifiers"`
+	Identifiers      map[string]*Identifier   `json:"identifiers"`
 	ReferenceManager ReferenceManager         `json:"reference_manager"`
 	Attributes       []AttributeScope         `json:"attributes"`
 	DebugInfo        DebugInfo                `json:"debug_info"`
+}
+
+type Identifier struct {
+	FullName       string         `json:"full_name"`
+	IdentifierType string         `json:"type"`
+	CairoType      string         `json:"cairo_type"`
+	Destination    string         `json:"destination"`
+	Pc             int            `json:"pc"`
+	Size           int            `json:"size"`
+	Members        map[string]any `json:"members"`
+	References     []Reference    `json:"references"`
+
+	// These fields are listed as any-typed fields before we need them.
+	Decorators any `json:"decorators"`
+	Value      any `json:"value"`
 }
 
 func (z ZeroProgram) MarshalToFile(filepath string) error {

--- a/pkg/parsers/zero/zero_test.go
+++ b/pkg/parsers/zero/zero_test.go
@@ -1,8 +1,9 @@
 package zero
 
 import (
-	starknetParser "github.com/NethermindEth/cairo-vm-go/pkg/parsers/starknet"
 	"testing"
+
+	starknetParser "github.com/NethermindEth/cairo-vm-go/pkg/parsers/starknet"
 
 	"github.com/stretchr/testify/require"
 )
@@ -220,41 +221,41 @@ func TestIdentifiers(t *testing.T) {
 	require.Equal(
 		t,
 		&ZeroProgram{
-			Identifiers: map[string]any{
-				"__main__.fib": map[string]any{
-					"decorators": make([]any, 0),
-					"pc":         float64(9),
-					"type":       "function",
+			Identifiers: map[string]*Identifier{
+				"__main__.fib": {
+					Decorators:     make([]any, 0),
+					Pc:             9,
+					IdentifierType: "function",
 				},
-				"__main__.BitwiseBuiltin": map[string]any{
-					"destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
-					"type":        "alias",
+				"__main__.BitwiseBuiltin": {
+					Destination:    "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+					IdentifierType: "alias",
 				},
-				"__main__.fill_array.Args": map[string]any{
-					"full_name": "__main__.fill_array.Args",
-					"members": map[string]any{
+				"__main__.fill_array.Args": {
+					FullName: "__main__.fill_array.Args",
+					Members: map[string]any{
 						"array": map[string]any{
 							"cairo_type": "felt*",
 							"offset":     float64(0),
 						},
 					},
-					"size": float64(1),
-					"type": "struct",
+					Size:           1,
+					IdentifierType: "struct",
 				},
-				"__main__.fill_array.__temp18": map[string]any{
-					"cairo_type": "felt",
-					"full_name":  "__main__.fill_array.__temp18",
-					"references": []any{
-						map[string]any{
-							"ap_tracking_data": map[string]any{
-								"group":  float64(26),
-								"offset": float64(1),
+				"__main__.fill_array.__temp18": {
+					CairoType: "felt",
+					FullName:  "__main__.fill_array.__temp18",
+					References: []Reference{
+						{
+							ApTrackingData: ApTracking{
+								Group:  26,
+								Offset: 1,
 							},
-							"pc":    float64(312),
-							"value": "[cast(ap + (-1), felt*)]",
+							Pc:    312,
+							Value: "[cast(ap + (-1), felt*)]",
 						},
 					},
-					"type": "reference",
+					IdentifierType: "reference",
 				},
 			},
 		},


### PR DESCRIPTION
This allows us to do less redundant type assertions while handling the zero prog identifiers.

We may go even further, but this step is enough for now to make zero hints handler less awkward.

The `.([]zero.Reference)` assertion was not working as the slice contained `[]any` instead.
Instead of rewriting the code to handle even more
weakly typed `any` values, this patch improves the Identifier objects typing.
This makes type assertions and slice conversions unnecessary.