### PR TITLE
pkg/hintrunner/zero: allow multiplication binary ops in references

### DIFF
--- a/pkg/hintrunner/zero/hintparser_test.go
+++ b/pkg/hintrunner/zero/hintparser_test.go
@@ -45,6 +45,26 @@ func TestHintParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			Parameter:         "cast([ap + (-5)] * [ap + (-1)], felt)",
+			ExpectedCellRefer: nil,
+			ExpectedResOperander: hinter.BinaryOp{
+				Operator: hinter.Mul,
+				Lhs:      hinter.ApCellRef(-5),
+				Rhs: hinter.Deref{
+					Deref: hinter.ApCellRef(-1),
+				},
+			},
+		},
+		{
+			Parameter:         "cast([ap] * 3, felt)",
+			ExpectedCellRefer: nil,
+			ExpectedResOperander: hinter.BinaryOp{
+				Operator: hinter.Mul,
+				Lhs:      hinter.ApCellRef(0),
+				Rhs:      hinter.Immediate{0, 0, 0, 3},
+			},
+		},
 	}
 
 	for _, test := range testSet {


### PR DESCRIPTION
References may include the multiplication inside them.

Let's take this like of code for the example:

    https://github.com/starkware-libs/cairo-lang/blob/caba294d82eeeccc3d86a158adb8ba209bf2d8fc/src/starkware/cairo/common/math.cairo#L193

It will produce a reference like this:
```json
    {
        "cairo_type": "felt",
        "full_name": "starkware.cairo.common.math.assert_le_felt.arc_prod",
        "references": [
            {
                "ap_tracking_data": {
                    "group": 1,
                    "offset": 8
                },
                "pc": 14,
                "value": "cast([ap + (-5)] * [ap + (-1)], felt)"
            }
        ],
        "type": "reference"
    }
```