### PR TITLE
implement cairo0 hints needed for assert_le_felt

### DIFF
--- a/pkg/hintrunner/core/hint.go
+++ b/pkg/hintrunner/core/hint.go
@@ -1319,9 +1319,9 @@ func (hint *AllocConstantSize) Execute(vm *VM.VirtualMachine, ctx *hinter.HintRu
 }
 
 type AssertLeFindSmallArc struct {
-	a             hinter.ResOperander
-	b             hinter.ResOperander
-	rangeCheckPtr hinter.ResOperander
+	A             hinter.ResOperander
+	B             hinter.ResOperander
+	RangeCheckPtr hinter.ResOperander
 }
 
 func (hint *AssertLeFindSmallArc) String() string {
@@ -1332,14 +1332,14 @@ func (hint *AssertLeFindSmallArc) Execute(vm *VM.VirtualMachine, ctx *hinter.Hin
 	primeOver3High := uint256.Int{6148914691236517206, 192153584101141168, 0, 0}
 	primeOver2High := uint256.Int{9223372036854775809, 288230376151711752, 0, 0}
 
-	a, err := hint.a.Resolve(vm)
+	a, err := hint.A.Resolve(vm)
 	if err != nil {
-		return fmt.Errorf("resolve a operand %s: %w", hint.a, err)
+		return fmt.Errorf("resolve a operand %s: %w", hint.A, err)
 	}
 
-	b, err := hint.b.Resolve(vm)
+	b, err := hint.B.Resolve(vm)
 	if err != nil {
-		return fmt.Errorf("resolve b operand %s: %w", hint.b, err)
+		return fmt.Errorf("resolve b operand %s: %w", hint.B, err)
 	}
 
 	aFelt, err := a.FieldElement()
@@ -1374,7 +1374,7 @@ func (hint *AssertLeFindSmallArc) Execute(vm *VM.VirtualMachine, ctx *hinter.Hin
 	// Exclude the largest arc after sorting
 	ctx.ExcludedArc = lengthsAndIndices[2].Position
 
-	rangeCheckPtrMemAddr, err := hinter.ResolveAsAddress(vm, hint.rangeCheckPtr)
+	rangeCheckPtrMemAddr, err := hinter.ResolveAsAddress(vm, hint.RangeCheckPtr)
 	if err != nil {
 		return fmt.Errorf("resolve range check pointer: %w", err)
 	}
@@ -1434,7 +1434,7 @@ func (hint *AssertLeFindSmallArc) Execute(vm *VM.VirtualMachine, ctx *hinter.Hin
 }
 
 type AssertLeIsFirstArcExcluded struct {
-	skipExcludeAFlag hinter.CellRefer
+	SkipExcludeAFlag hinter.CellRefer
 }
 
 func (hint *AssertLeIsFirstArcExcluded) String() string {
@@ -1442,7 +1442,7 @@ func (hint *AssertLeIsFirstArcExcluded) String() string {
 }
 
 func (hint *AssertLeIsFirstArcExcluded) Execute(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
-	addr, err := hint.skipExcludeAFlag.Get(vm)
+	addr, err := hint.SkipExcludeAFlag.Get(vm)
 	if err != nil {
 		return fmt.Errorf("get skipExcludeAFlag addr: %v", err)
 	}
@@ -1458,7 +1458,7 @@ func (hint *AssertLeIsFirstArcExcluded) Execute(vm *VM.VirtualMachine, ctx *hint
 }
 
 type AssertLeIsSecondArcExcluded struct {
-	skipExcludeBMinusA hinter.CellRefer
+	SkipExcludeBMinusA hinter.CellRefer
 }
 
 func (hint *AssertLeIsSecondArcExcluded) String() string {
@@ -1466,7 +1466,7 @@ func (hint *AssertLeIsSecondArcExcluded) String() string {
 }
 
 func (hint *AssertLeIsSecondArcExcluded) Execute(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
-	addr, err := hint.skipExcludeBMinusA.Get(vm)
+	addr, err := hint.SkipExcludeBMinusA.Get(vm)
 	if err != nil {
 		return fmt.Errorf("get skipExcludeBMinusA addr: %v", err)
 	}

--- a/pkg/hintrunner/core/hint_benchmark_test.go
+++ b/pkg/hintrunner/core/hint_benchmark_test.go
@@ -328,7 +328,7 @@ func BenchmarkAssertLeIsFirstArcExcluded(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 
 		hint := AssertLeIsFirstArcExcluded{
-			skipExcludeAFlag: skipExcludeAFlag,
+			SkipExcludeAFlag: skipExcludeAFlag,
 		}
 
 		err := hint.Execute(vm, &ctx)
@@ -356,7 +356,7 @@ func BenchmarkAssertLeIsSecondArcExcluded(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 
 		hint := AssertLeIsSecondArcExcluded{
-			skipExcludeBMinusA: skipExcludeBMinusA,
+			SkipExcludeBMinusA: skipExcludeBMinusA,
 		}
 
 		err := hint.Execute(vm, &ctx)
@@ -392,9 +392,9 @@ func BenchmarkAssertLeFindSmallArc(b *testing.B) {
 		r1 := utils.RandomFeltElement(rand)
 		r2 := utils.RandomFeltElement(rand)
 		hint := AssertLeFindSmallArc{
-			a:             hinter.Immediate(r1),
-			b:             hinter.Immediate(r2),
-			rangeCheckPtr: hinter.Deref{Deref: hinter.ApCellRef(0)},
+			A:             hinter.Immediate(r1),
+			B:             hinter.Immediate(r2),
+			RangeCheckPtr: hinter.Deref{Deref: hinter.ApCellRef(0)},
 		}
 
 		if err := hint.Execute(vm, &ctx); err != nil &&

--- a/pkg/hintrunner/core/hint_test.go
+++ b/pkg/hintrunner/core/hint_test.go
@@ -987,9 +987,9 @@ func TestAssertLeFindSmallArc(t *testing.T) {
 		utils.WriteTo(vm, VM.ExecutionSegment, vm.Context.Ap, mem.MemoryValueFromMemoryAddress(&addr))
 
 		hint := AssertLeFindSmallArc{
-			a:             hinter.Immediate(tc.aFelt),
-			b:             hinter.Immediate(tc.bFelt),
-			rangeCheckPtr: hinter.Deref{Deref: hinter.ApCellRef(0)},
+			A:             hinter.Immediate(tc.aFelt),
+			B:             hinter.Immediate(tc.bFelt),
+			RangeCheckPtr: hinter.Deref{Deref: hinter.ApCellRef(0)},
 		}
 
 		ctx := hinter.HintRunnerContext{
@@ -1027,7 +1027,7 @@ func TestAssertLeIsFirstArcExcluded(t *testing.T) {
 	var flag hinter.ApCellRef = 0
 
 	hint := AssertLeIsFirstArcExcluded{
-		skipExcludeAFlag: flag,
+		SkipExcludeAFlag: flag,
 	}
 
 	err := hint.Execute(vm, &ctx)
@@ -1053,7 +1053,7 @@ func TestAssertLeIsSecondArcExcluded(t *testing.T) {
 	var flag hinter.ApCellRef = 0
 
 	hint := AssertLeIsSecondArcExcluded{
-		skipExcludeBMinusA: flag,
+		SkipExcludeBMinusA: flag,
 	}
 
 	err := hint.Execute(vm, &ctx)

--- a/pkg/hintrunner/zero/hint_reference_resolver.go
+++ b/pkg/hintrunner/zero/hint_reference_resolver.go
@@ -33,6 +33,20 @@ func (m *hintReferenceResolver) GetReference(name string) (hinter.Reference, err
 	return nil, fmt.Errorf("missing reference %s", name)
 }
 
+// GetResOperander returns the result of GetReference type-asserted to ResOperander.
+// If reference is not found or it's not of ResOperander type, a non-nil error is returned.
+func (m *hintReferenceResolver) GetResOperander(name string) (hinter.ResOperander, error) {
+	ref, err := m.GetReference(name)
+	if err != nil {
+		return nil, err
+	}
+	op, ok := ref.(hinter.ResOperander)
+	if !ok {
+		return nil, fmt.Errorf("expected %s to be ResOperander (got %T)", name, ref)
+	}
+	return op, nil
+}
+
 // shortSymbolName turns a full symbol name like "a.b.c" into just "c".
 func shortSymbolName(name string) string {
 	i := strings.LastIndexByte(name, '.')

--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -1,10 +1,16 @@
 package zero
 
 const (
-	AllocSegmentCode string = "memory[ap] = segments.add()"
+	allocSegmentCode string = "memory[ap] = segments.add()"
 
 	// This is a very simple Cairo0 hint that allows us to test
 	// the identifier resolution code.
 	// Depending on the context, ids.a may be a complex reference.
-	TestAssignCode string = "memory[ap] = ids.a"
+	testAssignCode string = "memory[ap] = ids.a"
+
+	// assert_le_felt() hints.
+	assertLeFeltCode          string = "import itertools\n\nfrom starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\n# Find an arc less than PRIME / 3, and another less than PRIME / 2.\nlengths_and_indices = [(a, 0), (b - a, 1), (PRIME - 1 - b, 2)]\nlengths_and_indices.sort()\nassert lengths_and_indices[0][0] <= PRIME // 3 and lengths_and_indices[1][0] <= PRIME // 2\nexcluded = lengths_and_indices[2][1]\n\nmemory[ids.range_check_ptr + 1], memory[ids.range_check_ptr + 0] = (\n    divmod(lengths_and_indices[0][0], ids.PRIME_OVER_3_HIGH))\nmemory[ids.range_check_ptr + 3], memory[ids.range_check_ptr + 2] = (\n    divmod(lengths_and_indices[1][0], ids.PRIME_OVER_2_HIGH))"
+	assertLeFeltExcluded0Code string = "memory[ap] = 1 if excluded != 0 else 0"
+	assertLeFeltExcluded1Code string = "memory[ap] = 1 if excluded != 1 else 0"
+	assertLeFeltExcluded2Code string = "assert excluded == 2"
 )


### PR DESCRIPTION
In turn, `assert_le_felt` is needed for some other functions that use cairo0 hints, like `is_nn`.