### PR TITLE
implement is_nn Cairo0 hint

### DIFF
--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -1,7 +1,11 @@
 package zero
 
 const (
+	// This is a block for hint code strings where there is a single
+	// hint per function it belongs to (with some exceptions like testAssignCode).
 	allocSegmentCode string = "memory[ap] = segments.add()"
+	isLeFeltCode     string = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1"
+	assertLtFeltCode string = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
 
 	// This is a very simple Cairo0 hint that allows us to test
 	// the identifier resolution code.
@@ -13,4 +17,8 @@ const (
 	assertLeFeltExcluded0Code string = "memory[ap] = 1 if excluded != 0 else 0"
 	assertLeFeltExcluded1Code string = "memory[ap] = 1 if excluded != 1 else 0"
 	assertLeFeltExcluded2Code string = "assert excluded == 2"
+
+	// is_nn() hints.
+	isNNCode           string = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1"
+	isNNOutOfRangeCode string = "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1"
 )

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -4,6 +4,8 @@ import (
 	"math/bits"
 
 	"golang.org/x/exp/constraints"
+
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
 // Takes a uint64 and an int16 and outputs their addition as well
@@ -58,4 +60,15 @@ func Max[T constraints.Integer](a, b T) T {
 		return a
 	}
 	return b
+}
+
+// FeltLt implements `a < b` felt comparison.
+func FeltLt(a, b *fp.Element) bool {
+	return a.Cmp(b) == -1
+}
+
+// FeltLe implements `a <= b` felt comparison.
+func FeltLe(a, b *fp.Element) bool {
+	// a is less or equal than b if it's not greater than b.
+	return a.Cmp(b) != 1
 }


### PR DESCRIPTION
This hint uses the assert_le_felt beneath it, but
it was implemented beforehand.

This PR has no tests included since #204 is not solved yet. I used a couple of Cairo0 scripts to test this functionality with a set of different arguments to cover both hints that are a part of `is_nn` function.
(One of them handles negatives while another is for the non-negatives.)

Refs #164