### PR TITLE
WIP: output-based Cairo0 testing

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -112,7 +112,8 @@ func main() {
 					if len(output) > 0 {
 						fmt.Println("Program output:")
 						for _, val := range output {
-							fmt.Printf("\t%s\n", val)
+							// Cairo-run v0.11-0.13 pad the output lines with two spaces.
+							fmt.Printf("  %s\n", val)
 						}
 					}
 					return nil

--- a/integration_tests/output_tests/serialize_word.cairo
+++ b/integration_tests/output_tests/serialize_word.cairo
@@ -1,0 +1,9 @@
+%builtins output
+
+from starkware.cairo.common.serialize import serialize_word
+
+func main{output_ptr: felt*}() {
+    serialize_word('hello');
+    serialize_word(540);
+    return ();
+}


### PR DESCRIPTION
This is one of the options of how we can test Cairo0 code (hints included) without relying on two memory files being identical.

Refs #204