### PR TITLE
pkg/hintrunner/zero: fix nn isoutofrange hint

### DIFF
--- a/pkg/hintrunner/zero/zerohint_math.go
+++ b/pkg/hintrunner/zero/zerohint_math.go
@@ -205,7 +205,7 @@ func newIsNNOutOfRangeHint(a hinter.ResOperander) hinter.Hinter {
 			lhs.Sub(&utils.FeltZero, aFelt) //> -ids.a
 			lhs.Sub(&lhs, &utils.FeltOne)
 			var v memory.MemoryValue
-			if utils.FeltLt(aFelt, &utils.FeltMax128) {
+			if utils.FeltLt(&lhs, &utils.FeltMax128) {
 				v = memory.MemoryValueFromFieldElement(&utils.FeltZero)
 			} else {
 				v = memory.MemoryValueFromFieldElement(&utils.FeltOne)

--- a/pkg/hintrunner/zero/zerohint_math_test.go
+++ b/pkg/hintrunner/zero/zerohint_math_test.go
@@ -128,29 +128,54 @@ func TestZeroHintMath(t *testing.T) {
 		},
 
 		"IsNNOutOfRange": {
-			{
-				operanders: []*hintOperander{
-					{Name: "a", Kind: apRelative, Value: feltInt64(0)},
-				},
-				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newIsNNOutOfRangeHint(ctx.operanders["a"])
-				},
-				check: apValueEquals(feltUint64(0)),
-			},
+			// Note that "a" is (-a - 1).
 
 			{
 				operanders: []*hintOperander{
+					// (-a - 1) => (-1 - 1) => -2
 					{Name: "a", Kind: apRelative, Value: feltInt64(1)},
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
 					return newIsNNOutOfRangeHint(ctx.operanders["a"])
 				},
+				check: apValueEquals(feltUint64(1)),
+			},
+
+			{
+				operanders: []*hintOperander{
+					// (-a - 1) => (0 - 1) => -1
+					{Name: "a", Kind: apRelative, Value: feltInt64(0)},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newIsNNOutOfRangeHint(ctx.operanders["a"])
+				},
+				check: apValueEquals(feltUint64(1)),
+			},
+
+			{
+				operanders: []*hintOperander{
+					// (-a - 1) => (1 - 1) => 0
+					{Name: "a", Kind: apRelative, Value: feltInt64(-1)},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newIsNNOutOfRangeHint(ctx.operanders["a"])
+				},
 				check: apValueEquals(feltUint64(0)),
 			},
 
 			{
 				operanders: []*hintOperander{
-					{Name: "a", Kind: fpRelative, Value: feltInt64(-1)},
+					{Name: "a", Kind: apRelative, Value: feltAdd(&utils.FeltMax128, feltInt64(1))},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newIsNNOutOfRangeHint(ctx.operanders["a"])
+				},
+				check: apValueEquals(feltUint64(1)),
+			},
+
+			{
+				operanders: []*hintOperander{
+					{Name: "a", Kind: apRelative, Value: feltAdd(&utils.FeltMax128, feltInt64(2))},
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
 					return newIsNNOutOfRangeHint(ctx.operanders["a"])
@@ -166,26 +191,6 @@ func TestZeroHintMath(t *testing.T) {
 					return newIsNNOutOfRangeHint(ctx.operanders["a"])
 				},
 				check: apValueEquals(feltUint64(1)),
-			},
-
-			{
-				operanders: []*hintOperander{
-					{Name: "a", Kind: apRelative, Value: feltAdd(&utils.FeltMax128, feltInt64(1))},
-				},
-				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newIsNNOutOfRangeHint(ctx.operanders["a"])
-				},
-				check: apValueEquals(feltUint64(1)),
-			},
-
-			{
-				operanders: []*hintOperander{
-					{Name: "a", Kind: apRelative, Value: feltAdd(&utils.FeltMax128, feltInt64(-1))},
-				},
-				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newIsNNOutOfRangeHint(ctx.operanders["a"])
-				},
-				check: apValueEquals(feltUint64(0)),
 			},
 		},
 	})


### PR DESCRIPTION
It's `-a - 1 < rc_bound`, not just `a < rc_bound`. Due to a copy/paste mistake, a computed `lhs` (`-a - 1`) was never used.

Tests are adjusted, some clarifying comments are added.