### PR TITLE
pkg/hintrunner/zero: implement assert250bits Cairo0 hint

### DIFF
--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -9,6 +9,7 @@ const (
 	assertNotZeroCode  string = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'"
 	assertNNCode       string = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'"
 	assertNotEqualCode string = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'"
+	assert250bits      string = "from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)"
 
 	// This is a very simple Cairo0 hint that allows us to test
 	// the identifier resolution code.

--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -64,6 +64,8 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createAssertNNHinter(resolver)
 	case assertNotEqualCode:
 		return createAssertNotEqualHinter(resolver)
+	case assert250bits:
+		return createAssert250bitsHinter(resolver)
 	case testAssignCode:
 		return createTestAssignHinter(resolver)
 	case assertLeFeltCode:

--- a/pkg/hintrunner/zero/zerohint_math_test.go
+++ b/pkg/hintrunner/zero/zerohint_math_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/NethermindEth/cairo-vm-go/pkg/hintrunner/hinter"
+	"github.com/NethermindEth/cairo-vm-go/pkg/parsers/starknet"
 	"github.com/NethermindEth/cairo-vm-go/pkg/utils"
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
 func TestZeroHintMath(t *testing.T) {
@@ -477,6 +479,80 @@ func TestZeroHintMath(t *testing.T) {
 					return newSplitIntHint(ctx.operanders["output"], ctx.operanders["value"], ctx.operanders["base"], ctx.operanders["bound"])
 				},
 				errCheck: errorTextContains("assertion `split_int(): Limb 4 is out of range` failed"),
+			},
+		},
+
+		"Assert250bits": {
+			{
+				operanders: []*hintOperander{
+					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
+					{Name: "high", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 1)},
+					{Name: "value", Kind: apRelative, Value: feltInt64(3042)},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newAssert250bitsHint(ctx.operanders["low"], ctx.operanders["high"], ctx.operanders["value"])
+				},
+				check: allVarValueEquals(map[string]*fp.Element{
+					"low":  feltInt64(3042),
+					"high": feltInt64(0),
+				}),
+			},
+
+			{
+				operanders: []*hintOperander{
+					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
+					{Name: "high", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 1)},
+					{Name: "value", Kind: fpRelative, Value: feltInt64(4938538853994)},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newAssert250bitsHint(ctx.operanders["low"], ctx.operanders["high"], ctx.operanders["value"])
+				},
+				check: allVarValueEquals(map[string]*fp.Element{
+					"low":  feltInt64(4938538853994),
+					"high": feltInt64(0),
+				}),
+			},
+
+			{
+				operanders: []*hintOperander{
+					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
+					{Name: "high", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 1)},
+					{Name: "value", Kind: apRelative, Value: feltString("348329493943842849393993999999231222222222")},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newAssert250bitsHint(ctx.operanders["low"], ctx.operanders["high"], ctx.operanders["value"])
+				},
+				check: allVarValueEquals(map[string]*fp.Element{
+					"low":  feltString("220632583722801270961776596532341902734"),
+					"high": feltInt64(1023),
+				}),
+			},
+
+			{
+				operanders: []*hintOperander{
+					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
+					{Name: "high", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 1)},
+					{Name: "value", Kind: apRelative, Value: feltString("348329493943842849393124453993999999231222222222")},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newAssert250bitsHint(ctx.operanders["low"], ctx.operanders["high"], ctx.operanders["value"])
+				},
+				check: allVarValueEquals(map[string]*fp.Element{
+					"low":  feltString("302658603189151847763334509038790380942"),
+					"high": feltInt64(1023648380),
+				}),
+			},
+
+			{
+				operanders: []*hintOperander{
+					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
+					{Name: "high", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 1)},
+					{Name: "value", Kind: apRelative, Value: feltInt64(-233)},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newAssert250bitsHint(ctx.operanders["low"], ctx.operanders["high"], ctx.operanders["value"])
+				},
+				errCheck: errorTextContains("outside of the range [0, 2**250)"),
 			},
 		},
 	})

--- a/pkg/hintrunner/zero/zerohint_utils_test.go
+++ b/pkg/hintrunner/zero/zerohint_utils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	runnerutil "github.com/NethermindEth/cairo-vm-go/pkg/hintrunner/utils"
+	"github.com/NethermindEth/cairo-vm-go/pkg/parsers/starknet"
 	"github.com/NethermindEth/cairo-vm-go/pkg/vm"
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
 	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
@@ -23,6 +24,21 @@ func addrWithSegment(segment, offset uint64) *memory.MemoryAddress {
 		SegmentIndex: segment,
 		Offset:       offset,
 	}
+}
+
+func addrBuiltin(builtin starknet.Builtin, offset uint64) *builtinReference {
+	return &builtinReference{
+		builtin: builtin,
+		offset:  offset,
+	}
+}
+
+func feltString(s string) *fp.Element {
+	felt, err := new(fp.Element).SetString(s)
+	if err != nil {
+		panic(err)
+	}
+	return felt
 }
 
 func feltInt64(v int64) *fp.Element {

--- a/pkg/utils/constant.go
+++ b/pkg/utils/constant.go
@@ -16,7 +16,11 @@ var FeltOne = fp.Element{
 }
 
 // 1 << 128
+// same as 2 ** 128
 var FeltMax128 = fp.Element{18446744073700081665, 17407, 18446744073709551584, 576460752142434320}
+
+// 2 ** 250
+var FeltUpperBound = fp.Element{0xfffffff5cdf80011, 0x4cc3fff, 0xfffffffffffdbe00, 0x7ffff52ad780230}
 
 //
 // Uint256 Constants

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -96,3 +96,25 @@ func FeltMod(a, b *fp.Element) fp.Element {
 	result.SetBigInt(&tmpResult)
 	return result
 }
+
+func FeltDivRem(a, b *fp.Element) (div fp.Element, rem fp.Element) {
+	// It would be possible to compute the mod (rem) as `a - div*b`,
+	// but since felt div would yield a different result than bigint
+	// arithmetics, we can't use that trick here.
+	// divmod function used in Python cairovm does a non-felt divmod.
+	// Therefore, 450326666 / 136310839 is expected to have a result of 3,
+	// not 834010808316774569532950779803492285717614100391395442358316910417277897363.
+
+	var tmpA big.Int
+	var tmpB big.Int
+	var tmpDiv big.Int
+	var tmpRem big.Int
+	a.BigInt(&tmpA)
+	b.BigInt(&tmpB)
+	tmpDiv.DivMod(&tmpA, &tmpB, &tmpRem)
+
+	div.SetBigInt(&tmpDiv)
+	rem.SetBigInt(&tmpRem)
+
+	return div, rem
+}

--- a/pkg/utils/math_test.go
+++ b/pkg/utils/math_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"testing"
 
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,4 +33,34 @@ func TestOffsetRightNoOverflow(t *testing.T) {
 	res, isOverflow := SafeOffset(^uint64(0), -12)
 	assert.Equal(t, uint64(18446744073709551603), res)
 	assert.False(t, isOverflow)
+}
+
+func TestFeltDivRem(t *testing.T) {
+	type testCase struct {
+		a   fp.Element
+		b   fp.Element
+		div fp.Element
+		rem fp.Element
+	}
+	tests := []testCase{
+		{fp.NewElement(0), fp.NewElement(1), fp.NewElement(0), fp.NewElement(0)},
+		{fp.NewElement(10), fp.NewElement(2), fp.NewElement(5), fp.NewElement(0)},
+		{fp.NewElement(2), fp.NewElement(10), fp.NewElement(0), fp.NewElement(2)},
+		{fp.NewElement(10), fp.NewElement(9), fp.NewElement(1), fp.NewElement(1)},
+		{fp.NewElement(9), fp.NewElement(10), fp.NewElement(0), fp.NewElement(9)},
+		{fp.NewElement(102495), fp.NewElement(2), fp.NewElement(51247), fp.NewElement(1)},
+		{fp.NewElement(102495), fp.NewElement(23), fp.NewElement(4456), fp.NewElement(7)},
+		{fp.NewElement(102495), fp.NewElement(5), fp.NewElement(20499), fp.NewElement(0)},
+		{fp.NewElement(102495), fp.NewElement(102495), fp.NewElement(1), fp.NewElement(0)},
+		{fp.NewElement(102495), fp.NewElement(102495 / 5), fp.NewElement(5), fp.NewElement(0)},
+	}
+
+	for i, test := range tests {
+		haveDiv, haveRem := FeltDivRem(&test.a, &test.b)
+
+		if !test.div.Equal(&haveDiv) || !test.rem.Equal(&haveRem) {
+			t.Fatalf("test[%d]: %v divmod %v results mismatched:\nhave: %v, %v\nwant: %v, %v",
+				i, &test.a, &test.b, &haveDiv, &haveRem, test.div, test.rem)
+		}
+	}
 }


### PR DESCRIPTION
This hint required a builtins support from the test runner.

I tested this hint with our VM as well.
The results for tests are gathered from the cairo-run executions for the same values.