### PR TITLE
Add cairo0 sqrt hint

### DIFF
--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -34,15 +34,16 @@ const (
 	splitIntAssertRange string = "assert ids.value == 0, 'split_int(): value is out of range.'"
 	splitIntCode        string = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'"
 
+	// sqrt() hint.
+	sqrt string = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)"
+
 	// ------ Uint256 hints related code ------
 	uint256AddCode    string = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0"
 	uint256AddLowCode string = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0"
 	split64Code       string = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64"
 	uint256SignedNN   string = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0"
 
-	// sqrt() hints.
-	sqrt string = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)"
-
+	
 	// ------ Usort hints related code ------
 
 	// ------ Elliptic Curve hints related code ------

--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -40,6 +40,9 @@ const (
 	split64Code       string = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64"
 	uint256SignedNN   string = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0"
 
+	// sqrt() hints.
+	sqrt string = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)"
+
 	// ------ Usort hints related code ------
 
 	// ------ Elliptic Curve hints related code ------

--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -35,7 +35,7 @@ const (
 	splitIntCode        string = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'"
 
 	// sqrt() hint.
-	sqrt string = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)"
+	sqrtCode string = "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)"
 
 	// ------ Uint256 hints related code ------
 	uint256AddCode    string = "sum_low = ids.a.low + ids.b.low\nids.carry_low = 1 if sum_low >= ids.SHIFT else 0\nsum_high = ids.a.high + ids.b.high + ids.carry_low\nids.carry_high = 1 if sum_high >= ids.SHIFT else 0"
@@ -43,7 +43,6 @@ const (
 	split64Code       string = "ids.low = ids.a & ((1<<64) - 1)\nids.high = ids.a >> 64"
 	uint256SignedNN   string = "memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0"
 
-	
 	// ------ Usort hints related code ------
 
 	// ------ Elliptic Curve hints related code ------

--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -94,7 +94,7 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createSplit64Hinter(resolver)
 	case uint256SignedNN:
 		return createUint256SignedNNHinter(resolver)
-	case sqrt:
+	case sqrtCode:
 		return createSqrtHinter(resolver)
 	default:
 		return nil, fmt.Errorf("Not identified hint")

--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -94,6 +94,8 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createSplit64Hinter(resolver)
 	case uint256SignedNN:
 		return createUint256SignedNNHinter(resolver)
+	case sqrt:
+		return createSqrtHinter(resolver)
 	default:
 		return nil, fmt.Errorf("Not identified hint")
 	}

--- a/pkg/hintrunner/zero/zerohint_math_test.go
+++ b/pkg/hintrunner/zero/zerohint_math_test.go
@@ -481,7 +481,7 @@ func TestZeroHintMath(t *testing.T) {
 				errCheck: errorTextContains("assertion `split_int(): Limb 4 is out of range` failed"),
 			},
 		},
-
+		
 		"Assert250bits": {
 			{
 				operanders: []*hintOperander{
@@ -512,7 +512,7 @@ func TestZeroHintMath(t *testing.T) {
 					"high": feltInt64(0),
 				}),
 			},
-
+			
 			{
 				operanders: []*hintOperander{
 					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
@@ -527,7 +527,7 @@ func TestZeroHintMath(t *testing.T) {
 					"high": feltInt64(1023),
 				}),
 			},
-
+			
 			{
 				operanders: []*hintOperander{
 					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
@@ -542,7 +542,7 @@ func TestZeroHintMath(t *testing.T) {
 					"high": feltInt64(1023648380),
 				}),
 			},
-
+			
 			{
 				operanders: []*hintOperander{
 					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
@@ -553,6 +553,59 @@ func TestZeroHintMath(t *testing.T) {
 					return newAssert250bitsHint(ctx.operanders["low"], ctx.operanders["high"], ctx.operanders["value"])
 				},
 				errCheck: errorTextContains("outside of the range [0, 2**250)"),
+			},
+		},
+
+		"SqrtHint": {
+			// Sqrt sets output to ⌊√value⌋, the largest integer such that output² ≤ value, and stores that to output.
+			// Asserts output<bound.
+		
+			{
+				operanders: []*hintOperander{
+					{Name: "output", Kind: uninitialized},
+					{Name: "value", Kind: fpRelative, Value: feltInt64(25)},
+					{Name: "bound", Kind: fpRelative, Value: feltInt64(6)},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSqrtHint(ctx.operanders["output"], ctx.operanders["value"], ctx.operanders["bound"])
+				},
+				check: varValueEquals("output", feltInt64(5)),
+			},
+		
+			{
+				operanders: []*hintOperander{
+					{Name: "output", Kind: uninitialized},
+					{Name: "value", Kind: fpRelative, Value: feltInt64(0)},
+					{Name: "bound", Kind: fpRelative, Value: feltInt64(7)},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSqrtHint(ctx.operanders["output"], ctx.operanders["value"], ctx.operanders["bound"])
+				},
+				check: varValueEquals("output", feltInt64(0)),
+			},
+		
+			{
+				operanders: []*hintOperander{
+					{Name: "output", Kind: uninitialized},
+					{Name: "value", Kind: fpRelative, Value: feltInt64(50)},
+					{Name: "bound", Kind: fpRelative, Value: feltInt64(8)},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSqrtHint(ctx.operanders["output"], ctx.operanders["value"], ctx.operanders["bound"])
+				},
+				check: varValueEquals("output", feltInt64(7)),
+			},
+		
+			{
+				operanders: []*hintOperander{
+					{Name: "output", Kind: uninitialized},
+					{Name: "value", Kind: fpRelative, Value: feltInt64(100)},
+					{Name: "bound", Kind: fpRelative, Value: feltInt64(9)},
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSqrtHint(ctx.operanders["output"], ctx.operanders["value"], ctx.operanders["bound"])
+				},
+				errCheck: errorTextContains("assertion `sqrt(): Output 10 is out of range` failed"),
 			},
 		},
 	})

--- a/pkg/hintrunner/zero/zerohint_math_test.go
+++ b/pkg/hintrunner/zero/zerohint_math_test.go
@@ -481,7 +481,7 @@ func TestZeroHintMath(t *testing.T) {
 				errCheck: errorTextContains("assertion `split_int(): Limb 4 is out of range` failed"),
 			},
 		},
-		
+
 		"Assert250bits": {
 			{
 				operanders: []*hintOperander{
@@ -512,7 +512,7 @@ func TestZeroHintMath(t *testing.T) {
 					"high": feltInt64(0),
 				}),
 			},
-			
+
 			{
 				operanders: []*hintOperander{
 					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
@@ -527,7 +527,7 @@ func TestZeroHintMath(t *testing.T) {
 					"high": feltInt64(1023),
 				}),
 			},
-			
+
 			{
 				operanders: []*hintOperander{
 					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
@@ -542,7 +542,7 @@ func TestZeroHintMath(t *testing.T) {
 					"high": feltInt64(1023648380),
 				}),
 			},
-			
+
 			{
 				operanders: []*hintOperander{
 					{Name: "low", Kind: reference, Value: addrBuiltin(starknet.RangeCheck, 0)},
@@ -557,55 +557,50 @@ func TestZeroHintMath(t *testing.T) {
 		},
 
 		"SqrtHint": {
-			// Sqrt sets output to ⌊√value⌋, the largest integer such that output² ≤ value, and stores that to output.
-			// Asserts output<bound.
-		
+			// Sqrt sets root to ⌊√value⌋, the largest integer such that root² ≤ value.
+
 			{
 				operanders: []*hintOperander{
-					{Name: "output", Kind: uninitialized},
+					{Name: "root", Kind: uninitialized},
 					{Name: "value", Kind: fpRelative, Value: feltInt64(25)},
-					{Name: "bound", Kind: fpRelative, Value: feltInt64(6)},
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newSqrtHint(ctx.operanders["output"], ctx.operanders["value"], ctx.operanders["bound"])
+					return newSqrtHint(ctx.operanders["root"], ctx.operanders["value"])
 				},
-				check: varValueEquals("output", feltInt64(5)),
+				check: varValueEquals("root", feltInt64(5)),
 			},
-		
+
 			{
 				operanders: []*hintOperander{
-					{Name: "output", Kind: uninitialized},
+					{Name: "root", Kind: uninitialized},
 					{Name: "value", Kind: fpRelative, Value: feltInt64(0)},
-					{Name: "bound", Kind: fpRelative, Value: feltInt64(7)},
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newSqrtHint(ctx.operanders["output"], ctx.operanders["value"], ctx.operanders["bound"])
+					return newSqrtHint(ctx.operanders["root"], ctx.operanders["value"])
 				},
-				check: varValueEquals("output", feltInt64(0)),
+				check: varValueEquals("root", feltInt64(0)),
 			},
-		
+
 			{
 				operanders: []*hintOperander{
-					{Name: "output", Kind: uninitialized},
+					{Name: "root", Kind: uninitialized},
 					{Name: "value", Kind: fpRelative, Value: feltInt64(50)},
-					{Name: "bound", Kind: fpRelative, Value: feltInt64(8)},
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newSqrtHint(ctx.operanders["output"], ctx.operanders["value"], ctx.operanders["bound"])
+					return newSqrtHint(ctx.operanders["root"], ctx.operanders["value"])
 				},
-				check: varValueEquals("output", feltInt64(7)),
+				check: varValueEquals("root", feltInt64(7)),
 			},
-		
+
 			{
 				operanders: []*hintOperander{
-					{Name: "output", Kind: uninitialized},
-					{Name: "value", Kind: fpRelative, Value: feltInt64(100)},
-					{Name: "bound", Kind: fpRelative, Value: feltInt64(9)},
+					{Name: "root", Kind: uninitialized},
+					{Name: "value", Kind: fpRelative, Value: feltInt64(-128)},
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newSqrtHint(ctx.operanders["output"], ctx.operanders["value"], ctx.operanders["bound"])
+					return newSqrtHint(ctx.operanders["root"], ctx.operanders["value"])
 				},
-				errCheck: errorTextContains("assertion `sqrt(): Output 10 is out of range` failed"),
+				errCheck: errorTextContains("outside of the range [0, 2**250)"),
 			},
 		},
 	})


### PR DESCRIPTION
### feat: Implement "Sqrt" hint for calculating square roots within specified range

This commit introduces a cairo0 hint named "Sqrt" to calculate the square root of a given value while ensuring it falls within a specified range ([0, 2**250)). 

The calculation utilizes the [Sqrt()](https://github.com/holiman/uint256/blob/v1.2.3/uint256.go#L1307) function from the `"github.com/holiman/uint256"` library, setting z (root) to ⌊√x⌋ (value), the largest integer such that z² ≤ x, and returns z. 

To ensure the value remains within the specified range, the `FeltLt()` function from `"github.com/NethermindEth/cairo-vm-go/pkg/utils"` is utilized.

Accompanying tests cover various scenarios:
- Testing the square root of 25, which is expected to be 5.
- Handling zero input value, which is expected to be 0
- Verifying the square root of 50, expected to be 7.xxx.... (rounded to 7).
- Validating the square root of -127, which is expected to fail as it falls outside of the range [0, 2**250)

Relevant link:
[https://github.com/holiman/uint256/blob/v1.2.3/uint256.go#L1307](https://github.com/holiman/uint256/blob/v1.2.3/uint256.go#L1307)
