### PR TITLE
[feat]: Annotate usort and dict hints + few improvements 

### DIFF
--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -8,12 +8,10 @@ import (
 	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
-// SquashDictInnerAssertLenKeysHint hint asserts the length of the `keys`
-// descending list during the squashing process.
+// SquashDictInnerAssertLenKeysHint hint asserts that the length
+// of the `keys` descending list is zero during the squashing process
 //
 // `newSquashDictInnerAssertLenKeysHint` doesn't take any operander as argument
-//
-// `newSquashDictInnerAssertLenKeysHint` asserts that `keys` length is zero
 func newSquashDictInnerAssertLenKeysHint() hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "SquashDictInnerAssertLenKeys",

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -8,7 +8,7 @@ import (
 	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
-// SquashDictInnerAssertLenKeysHint hint asserts that the length
+// SquashDictInnerAssertLenKeys hint asserts that the length
 // of the `keys` descending list is zero during the squashing process
 //
 // `newSquashDictInnerAssertLenKeysHint` doesn't take any operander as argument

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -8,9 +8,15 @@ import (
 	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
+// SquashDictInnerAssertLenKeysHint hint asserts the length of the `keys`
+// descending list during the squashing process.
+//
+// `newSquashDictInnerAssertLenKeysHint` doesn't take any operander as argument
+//
+// `newSquashDictInnerAssertLenKeysHint` asserts that `keys` length is zero
 func newSquashDictInnerAssertLenKeysHint() hinter.Hinter {
 	return &GenericZeroHinter{
-		Name: "SquashDictInnerAssertKeys",
+		Name: "SquashDictInnerAssertLenKeys",
 		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
 			//> assert len(keys) == 0
 			keys_, err := ctx.ScopeManager.GetVariableValue("keys")

--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -538,7 +538,7 @@ func createEcDoubleAssignNewXV1Hinter(resolver hintReferenceResolver) (hinter.Hi
 	return newEcDoubleAssignNewXV1Hint(slope, point), nil
 }
 
-// ComputeSlopeV1Hint hint computes the slope between two points on an elliptic curve
+// ComputeSlopeV1 hint computes the slope between two points on an elliptic curve
 //
 // `newComputeSlopeV1Hint` takes 2 operanders as arguments
 //   - `point0` is the first point on an elliptic curve to operate on

--- a/pkg/hintrunner/zero/zerohint_others.go
+++ b/pkg/hintrunner/zero/zerohint_others.go
@@ -32,7 +32,7 @@ func createVMExitScopeHinter() (hinter.Hinter, error) {
 	}, nil
 }
 
-// MemcpyEnterScopeHint hint enters a new scope for the memory copy operation with a specified length
+// MemcpyEnterScope hint enters a new scope for the memory copy operation with a specified length
 //
 // `newMemcpyEnterScopeHint` takes 1 operander as argument
 //   - `len` is the length value that is added in the new scope

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -10,11 +10,11 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
-// UsortEnterScopeHinter hint enters a new scope with `__usort_max_size` value
+// UsortEnterScope hint enters a new scope with `__usort_max_size` value
 //
-// `newUsortEnterScopeHinter` doesn't take any operander as argument
+// `newUsortEnterScopeHint` doesn't take any operander as argument
 //
-// `newUsortEnterScopeHinter` gets from the current scope `__usort_max_size`
+// `newUsortEnterScopeHint` gets from the current scope `__usort_max_size`
 // value and enters a new scope with this same value
 func newUsortEnterScopeHint() hinter.Hinter {
 	return &GenericZeroHinter{
@@ -132,7 +132,7 @@ func createUsortVerifyHinter(resolver hintReferenceResolver) (hinter.Hinter, err
 	return newUsortVerifyHint(value), nil
 }
 
-// UsortVerifyMultiplicityBodyHint hint processes each position of a specific value
+// UsortVerifyMultiplicityBody hint processes each position of a specific value
 // in the input (array of fields), updating indices for verification
 //
 // `newUsortVerifyMultiplicityBodyHint` takes one operander as argument

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -40,7 +40,7 @@ func createUsortEnterScopeHinter() (hinter.Hinter, error) {
 	return newUsortEnterScopeHint(), nil
 }
 
-// UsortVerifyMultiplicityAssert hint checks that the "positions" variable in scope
+// UsortVerifyMultiplicityAssert hint checks that the `positions` variable in scope
 // doesn't contain any value
 //
 // `newUsortVerifyMultiplicityAssertHint` doesn't take any operander as argument

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -14,8 +14,8 @@ import (
 //
 // `newUsortEnterScopeHint` doesn't take any operander as argument
 //
-// `newUsortEnterScopeHint` gets from the current scope `__usort_max_size`
-// value and enters a new scope with this same value
+// `newUsortEnterScopeHint` gets `__usort_max_size` value from the current
+// scope and enters a new scope with this same value
 func newUsortEnterScopeHint() hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "UsortEnterScope",

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -77,10 +77,10 @@ func createUsortVerifyMultiplicityAssertHinter() (hinter.Hinter, error) {
 }
 
 // UsortVerify hint prepares for verifying the presence of duplicates of
-// a specific value in the input (array of fields)
+// a specific value in the sorted output (array of fields)
 //
 // `newUsortVerifyHint` takes one operander as argument
-//   - `value` is the value at the given position in the input
+//   - `value` is the value at the given position in the output
 //
 // `last_pos` is set to zero
 // `positions` is set to the reversed order list associated with `ids.value`
@@ -132,13 +132,14 @@ func createUsortVerifyHinter(resolver hintReferenceResolver) (hinter.Hinter, err
 	return newUsortVerifyHint(value), nil
 }
 
-// UsortVerifyMultiplicityBody hint processes each position of a specific value
-// in the input (array of fields), updating indices for verification
+// UsortVerifyMultiplicityBody hint extracts a specific value
+// of the sorted output with `pop`, updating indices for the verification
+// of the next value
 //
 // `newUsortVerifyMultiplicityBodyHint` takes one operander as argument
 //   - `nextItemIndex` is the index of the next item
 //
-// `next_item_index` is set to `current_pos - last_pos`
+// `next_item_index` is set to `current_pos - last_pos` for the next iteration
 // `newUsortVerifyMultiplicityBodyHint` assigns `last_pos` in the current scope
 func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinter.Hinter {
 	return &GenericZeroHinter{

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -14,8 +14,8 @@ import (
 //
 // `newUsortEnterScopeHinter` doesn't take any operander as argument
 //
-// `newUsortEnterScopeHinter` gets from the current scope `__usort_max_size` value
-// And enters a new scope with this same value
+// `newUsortEnterScopeHinter` gets from the current scope `__usort_max_size`
+// value and enters a new scope with this same value
 func newUsortEnterScopeHint() hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "UsortEnterScope",
@@ -40,13 +40,13 @@ func createUsortEnterScopeHinter() (hinter.Hinter, error) {
 	return newUsortEnterScopeHint(), nil
 }
 
-// UsortVerifyMultiplicityAssert hint asserts that all occurrences of a specific value
-// have been accounted for in the verification process
+// UsortVerifyMultiplicityAssert hint checks that the "positions" variable in scope
+// doesn't contain any value
 //
 // `newUsortVerifyMultiplicityAssertHint` doesn't take any operander as argument
 //
-// `newUsortVerifyMultiplicityAssertHint` checks that the "positions" variable in scope
-// doesn't contain any value
+// This hint is used when sorting an array of field elements while removing duplicates
+// in `usort` Cairo function
 func newUsortVerifyMultiplicityAssertHint() hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "UsortVerifyMultiplicityAssert",
@@ -76,12 +76,15 @@ func createUsortVerifyMultiplicityAssertHinter() (hinter.Hinter, error) {
 	return newUsortEnterScopeHint(), nil
 }
 
-// UsortVerify hint prepares for verifying the multiplicity of a specific value
-// in the sorted output by reversing its positions list
+// UsortVerify hint prepares for verifying the presence of duplicates of
+// a specific value in the input (array of fields)
 //
 // `newUsortVerifyHint` takes one operander as argument
-// `value` is the value at the given position in the lsit
+//   - `value` is the value at the given position in the input
 //
+// `last_pos` is set to zero
+// `positions` is set to the reversed order list associated with `ids.value`
+// key in `positions_dict`
 // `newUsortVerifyHint` assigns `last_pos` and `positions` in the current scope
 func newUsortVerifyHint(value hinter.ResOperander) hinter.Hinter {
 	return &GenericZeroHinter{
@@ -130,11 +133,12 @@ func createUsortVerifyHinter(resolver hintReferenceResolver) (hinter.Hinter, err
 }
 
 // UsortVerifyMultiplicityBodyHint hint processes each position of a specific value
-// in the sorted output, updating indices for verification.
+// in the input (array of fields), updating indices for verification
 //
 // `newUsortVerifyMultiplicityBodyHint` takes one operander as argument
-// `nextItemIndex` is the value at the given position in the lsit
+//   - `nextItemIndex` is the index of the next item
 //
+// `next_item_index` is set to `current_pos - last_pos`
 // `newUsortVerifyMultiplicityBodyHint` assigns `last_pos` in the current scope
 func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinter.Hinter {
 	return &GenericZeroHinter{

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -10,7 +10,13 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
-func newUsortEnterScopeHinter() hinter.Hinter {
+// UsortEnterScopeHinter hint enters a new scope with `__usort_max_size` value
+//
+// `newUsortEnterScopeHinter` doesn't take any operander as argument
+//
+// `newUsortEnterScopeHinter` gets from the current scope `__usort_max_size` value
+// And enters a new scope with this same value
+func newUsortEnterScopeHint() hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "UsortEnterScope",
 		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
@@ -31,10 +37,17 @@ func newUsortEnterScopeHinter() hinter.Hinter {
 }
 
 func createUsortEnterScopeHinter() (hinter.Hinter, error) {
-	return newUsortEnterScopeHinter(), nil
+	return newUsortEnterScopeHint(), nil
 }
 
-func newUsortVerifyMultiplicityAssertHinter() hinter.Hinter {
+// UsortVerifyMultiplicityAssert hint asserts that all occurrences of a specific value
+// have been accounted for in the verification process
+//
+// `newUsortVerifyMultiplicityAssertHint` doesn't take any operander as argument
+//
+// `newUsortVerifyMultiplicityAssertHint` checks that the "positions" variable in scope
+// doesn't contain any value
+func newUsortVerifyMultiplicityAssertHint() hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "UsortVerifyMultiplicityAssert",
 		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
@@ -60,10 +73,17 @@ func newUsortVerifyMultiplicityAssertHinter() hinter.Hinter {
 }
 
 func createUsortVerifyMultiplicityAssertHinter() (hinter.Hinter, error) {
-	return newUsortEnterScopeHinter(), nil
+	return newUsortEnterScopeHint(), nil
 }
 
-func newUsortVerifyHinter(value hinter.ResOperander) hinter.Hinter {
+// UsortVerify hint prepares for verifying the multiplicity of a specific value
+// in the sorted output by reversing its positions list
+//
+// `newUsortVerifyHint` takes one operander as argument
+// `value` is the value at the given position in the lsit
+//
+// `newUsortVerifyHint` assigns `last_pos` and `positions` in the current scope
+func newUsortVerifyHint(value hinter.ResOperander) hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "UsortVerify",
 		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
@@ -106,9 +126,16 @@ func createUsortVerifyHinter(resolver hintReferenceResolver) (hinter.Hinter, err
 		return nil, err
 	}
 
-	return newUsortVerifyHinter(value), nil
+	return newUsortVerifyHint(value), nil
 }
 
+// UsortVerifyMultiplicityBodyHint hint processes each position of a specific value
+// in the sorted output, updating indices for verification.
+//
+// `newUsortVerifyMultiplicityBodyHint` takes one operander as argument
+// `nextItemIndex` is the value at the given position in the lsit
+//
+// `newUsortVerifyMultiplicityBodyHint` assigns `current_pos` and `last_pos` in the current scope
 func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "UsortVerifyMultiplicityBody",

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -135,7 +135,7 @@ func createUsortVerifyHinter(resolver hintReferenceResolver) (hinter.Hinter, err
 // `newUsortVerifyMultiplicityBodyHint` takes one operander as argument
 // `nextItemIndex` is the value at the given position in the lsit
 //
-// `newUsortVerifyMultiplicityBodyHint` assigns `current_pos` and `last_pos` in the current scope
+// `newUsortVerifyMultiplicityBodyHint` assigns `last_pos` in the current scope
 func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "UsortVerifyMultiplicityBody",
@@ -159,6 +159,7 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return err
 			}
 
+			// TODO : This doesn't make sense as currentPos is the value just before
 			currentPos, err := ctx.ScopeManager.GetVariableValue("current_pos")
 			if err != nil {
 				return err
@@ -194,6 +195,7 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return err
 			}
 
+			// TODO : Only last_pos should be assigned in current scope
 			// Save `current_pos` and `last_pos` values in scope variables
 			return ctx.ScopeManager.AssignVariables(map[string]any{
 				"current_pos": newCurrentPos,

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -164,7 +164,8 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return err
 			}
 
-			// TODO : This doesn't make sense as currentPos is the value just before
+			// TODO : This is not correct, `newCurrentPos` should be used
+			// and there is not `current_pos` variable to retrieve in scope
 			currentPos, err := ctx.ScopeManager.GetVariableValue("current_pos")
 			if err != nil {
 				return err

--- a/pkg/hintrunner/zero/zerohint_usort_test.go
+++ b/pkg/hintrunner/zero/zerohint_usort_test.go
@@ -18,7 +18,7 @@ func TestZeroHintUsort(t *testing.T) {
 					})
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newUsortEnterScopeHinter()
+					return newUsortEnterScopeHint()
 				},
 				check: varValueInScopeEquals("__usort_max_size", feltUint64(1)),
 			},
@@ -32,7 +32,7 @@ func TestZeroHintUsort(t *testing.T) {
 					}
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newUsortVerifyMultiplicityAssertHinter()
+					return newUsortVerifyMultiplicityAssertHint()
 				},
 				errCheck: errorTextContains("assertion `len(positions) == 0` failed"),
 			},
@@ -44,7 +44,7 @@ func TestZeroHintUsort(t *testing.T) {
 					}
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newUsortVerifyMultiplicityAssertHinter()
+					return newUsortVerifyMultiplicityAssertHint()
 				},
 				errCheck: errorIsNil,
 			},
@@ -63,7 +63,7 @@ func TestZeroHintUsort(t *testing.T) {
 					{Name: "value", Kind: fpRelative, Value: feltUint64(0)},
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newUsortVerifyHinter(ctx.operanders["value"])
+					return newUsortVerifyHint(ctx.operanders["value"])
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					positions, err := ctx.runnerContext.ScopeManager.GetVariableValue("positions")


### PR DESCRIPTION
@cicr99  I also renamed all `new...` function that ended with `Hinter` instead of `Hint`

Corrected the wrong name `SquashDictInnerAssertKeys` instead of `SquashDictInnerAssertLenKeys` 

Note : UsortVerifyMultiplicityBody is wrongly implemented