### PR TITLE
feat: Run separate cairo integration test files as a separate Go test

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ Integration tests are run with:
 make integration
 ```
 
+Integration tests are run with filters in the following two methods, with the first method having higher priority.
+
+```bash
+#1) set global environment variable `INTEGRATION_TESTS_FILTERS`
+export INTEGRATION_TESTS_FILTERS=fib,alloc
+make integration
+
+#2) set by editing `INTEGRATION_TESTS_FILTERS=` in the `./integration_tests/.env` file
+make integration
+```
+
 If you want to execute all tests of the project:
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o=
 github.com/holiman/uint256 v1.2.3/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/integration_tests/.env
+++ b/integration_tests/.env
@@ -1,0 +1,2 @@
+# Set to run a specific file test (ex. fib.cairo)
+INTEGRATION_TESTS_FILTER=

--- a/integration_tests/.env
+++ b/integration_tests/.env
@@ -1,2 +1,2 @@
-# Set to run a specific file test (ex. fib.cairo)
-INTEGRATION_TESTS_FILTER=
+# Set to run some specific file tests (ex. fib.cairo,alloc.cairo)
+INTEGRATION_TESTS_FILTERS=

--- a/integration_tests/cairozero_test.go
+++ b/integration_tests/cairozero_test.go
@@ -27,7 +27,9 @@ func TestCairoZeroFiles(t *testing.T) {
 		t.Errorf("Error loading .env file: %v", err)
 	}
 
-	filter := os.Getenv("INTEGRATION_TESTS_FILTER")
+	filtersRaw := os.Getenv("INTEGRATION_TESTS_FILTERS")
+	filtersRaw = strings.TrimSpace(filtersRaw)
+	filters := strings.Split(filtersRaw, ",")
 
 	for _, dirEntry := range testFiles {
 		if dirEntry.IsDir() || isGeneratedFile(dirEntry.Name()) {
@@ -36,9 +38,21 @@ func TestCairoZeroFiles(t *testing.T) {
 
 		path := filepath.Join(root, dirEntry.Name())
 
-		if !strings.Contains(path, filter) {
+		matched := false
+		if len(filters) == 0 {
+			matched = true
+		} else {
+			for _, filter := range filters {
+				if strings.Contains(dirEntry.Name(), strings.TrimSpace(filter)) {
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched {
 			continue
 		}
+
 		t.Logf("testing: %s\n", path)
 
 		compiledOutput, err := compileZeroCode(path)

--- a/integration_tests/cairozero_test.go
+++ b/integration_tests/cairozero_test.go
@@ -22,12 +22,11 @@ func TestCairoZeroFiles(t *testing.T) {
 
 	// Get the filter value from the environment variable
 	// filter is for debugging purposes
-	err = godotenv.Load("./.env")
-	if err != nil {
-		t.Errorf("Error loading .env file: %v", err)
-	}
-
 	filtersRaw := os.Getenv("INTEGRATION_TESTS_FILTERS")
+	if filtersRaw == "" {
+		godotenv.Load("./.env")
+		filtersRaw = os.Getenv("INTEGRATION_TESTS_FILTERS")
+	}
 	filtersRaw = strings.TrimSpace(filtersRaw)
 	filters := strings.Split(filtersRaw, ",")
 

--- a/integration_tests/cairozero_test.go
+++ b/integration_tests/cairozero_test.go
@@ -22,7 +22,7 @@ type Filter struct {
 func (f *Filter) init() {
 	filtersRaw := os.Getenv("INTEGRATION_TESTS_FILTERS")
 	if filtersRaw == "" {
-		godotenv.Load("./.env")
+		_ = godotenv.Load("./.env")
 		filtersRaw = os.Getenv("INTEGRATION_TESTS_FILTERS")
 	}
 	filters := strings.Split(filtersRaw, ",")

--- a/integration_tests/cairozero_test.go
+++ b/integration_tests/cairozero_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/NethermindEth/cairo-vm-go/pkg/vm"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
+	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,8 +20,14 @@ func TestCairoZeroFiles(t *testing.T) {
 	testFiles, err := os.ReadDir(root)
 	require.NoError(t, err)
 
+	// Get the filter value from the environment variable
 	// filter is for debugging purposes
-	filter := ""
+	err = godotenv.Load("./.env")
+	if err != nil {
+		t.Errorf("Error loading .env file: %v", err)
+	}
+
+	filter := os.Getenv("INTEGRATION_TESTS_FILTER")
 
 	for _, dirEntry := range testFiles {
 		if dirEntry.IsDir() || isGeneratedFile(dirEntry.Name()) {


### PR DESCRIPTION
Resolves #201 

First checking if the environment variable `INTEGRATION_TESTS_FILTERS` is set in the console.
And if not, then load it from the .env file. 
