### PR TITLE
refactor: move GetConsecutiveValues functionality to memory package

### DIFF
--- a/pkg/hintrunner/hinter/operand.go
+++ b/pkg/hintrunner/hinter/operand.go
@@ -231,25 +231,6 @@ func (v Immediate) ApplyApTracking(hint, ref zero.ApTracking) Reference {
 	return v
 }
 
-func GetConsecutiveValues(vm *VM.VirtualMachine, addr mem.MemoryAddress, size int16) ([]mem.MemoryValue, error) {
-	values := make([]mem.MemoryValue, size)
-	for i := int16(0); i < size; i++ {
-		nAddr, err := addr.AddOffset(i)
-		if err != nil {
-			return nil, err
-		}
-
-		v, err := vm.Memory.ReadFromAddress(&nAddr)
-		if err != nil {
-			return nil, err
-		}
-
-		values[i] = v
-	}
-
-	return values, nil
-}
-
 func WriteToNthStructField(vm *VM.VirtualMachine, addr mem.MemoryAddress, value mem.MemoryValue, field int16) error {
 	nAddr, err := addr.AddOffset(field)
 	if err != nil {

--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -36,7 +36,7 @@ func newEcNegateHint(point hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			pointMemoryValues, err := hinter.GetConsecutiveValues(vm, pointAddr, int16(6))
+			pointMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(pointAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -161,7 +161,7 @@ func newFastEcAddAssignNewXHint(slope, point0, point1 hinter.ResOperander) hinte
 			if err != nil {
 				return err
 			}
-			slopeMemoryValues, err := hinter.GetConsecutiveValues(vm, slopeAddr, int16(3))
+			slopeMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(slopeAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func newFastEcAddAssignNewXHint(slope, point0, point1 hinter.ResOperander) hinte
 			if err != nil {
 				return err
 			}
-			point0MemoryValues, err := hinter.GetConsecutiveValues(vm, point0Addr, int16(6))
+			point0MemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(point0Addr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -179,7 +179,7 @@ func newFastEcAddAssignNewXHint(slope, point0, point1 hinter.ResOperander) hinte
 			if err != nil {
 				return err
 			}
-			point1MemoryValues, err := hinter.GetConsecutiveValues(vm, point1Addr, int16(3))
+			point1MemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(point1Addr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -353,7 +353,7 @@ func newEcDoubleSlopeV1Hint(point hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			pointMemoryValues, err := hinter.GetConsecutiveValues(vm, pointAddr, int16(6))
+			pointMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(pointAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -487,7 +487,7 @@ func newEcDoubleAssignNewXV1Hint(slope, point hinter.ResOperander) hinter.Hinter
 			if err != nil {
 				return err
 			}
-			slopeMemoryValues, err := hinter.GetConsecutiveValues(vm, slopeAddr, int16(3))
+			slopeMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(slopeAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -496,7 +496,7 @@ func newEcDoubleAssignNewXV1Hint(slope, point hinter.ResOperander) hinter.Hinter
 			if err != nil {
 				return err
 			}
-			pointMemoryValues, err := hinter.GetConsecutiveValues(vm, pointAddr, int16(6))
+			pointMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(pointAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -654,7 +654,7 @@ func newComputeSlopeV1Hint(point0, point1 hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			point0MemoryValues, err := hinter.GetConsecutiveValues(vm, point0Addr, int16(6))
+			point0MemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(point0Addr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -663,7 +663,7 @@ func newComputeSlopeV1Hint(point0, point1 hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			point1MemoryValues, err := hinter.GetConsecutiveValues(vm, point1Addr, int16(6))
+			point1MemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(point1Addr, int16(6))
 			if err != nil {
 				return err
 			}

--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -36,7 +36,7 @@ func newEcNegateHint(point hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			pointMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(pointAddr, int16(6))
+			pointMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(pointAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -161,7 +161,7 @@ func newFastEcAddAssignNewXHint(slope, point0, point1 hinter.ResOperander) hinte
 			if err != nil {
 				return err
 			}
-			slopeMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(slopeAddr, int16(6))
+			slopeMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(slopeAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func newFastEcAddAssignNewXHint(slope, point0, point1 hinter.ResOperander) hinte
 			if err != nil {
 				return err
 			}
-			point0MemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(point0Addr, int16(6))
+			point0MemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(point0Addr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -179,7 +179,7 @@ func newFastEcAddAssignNewXHint(slope, point0, point1 hinter.ResOperander) hinte
 			if err != nil {
 				return err
 			}
-			point1MemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(point1Addr, int16(6))
+			point1MemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(point1Addr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -353,7 +353,7 @@ func newEcDoubleSlopeV1Hint(point hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			pointMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(pointAddr, int16(6))
+			pointMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(pointAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -431,7 +431,7 @@ func newReduceV1Hint(x hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			xMemoryValues, err := hinter.GetConsecutiveValues(vm, xAddr, int16(3))
+			xMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(xAddr, int16(3))
 			if err != nil {
 				return err
 			}
@@ -487,7 +487,7 @@ func newEcDoubleAssignNewXV1Hint(slope, point hinter.ResOperander) hinter.Hinter
 			if err != nil {
 				return err
 			}
-			slopeMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(slopeAddr, int16(6))
+			slopeMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(slopeAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -496,7 +496,7 @@ func newEcDoubleAssignNewXV1Hint(slope, point hinter.ResOperander) hinter.Hinter
 			if err != nil {
 				return err
 			}
-			pointMemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(pointAddr, int16(6))
+			pointMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(pointAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -654,7 +654,7 @@ func newComputeSlopeV1Hint(point0, point1 hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			point0MemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(point0Addr, int16(6))
+			point0MemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(point0Addr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -663,7 +663,7 @@ func newComputeSlopeV1Hint(point0, point1 hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			point1MemoryValues, err := mem.InitializeEmptyMemory().GetConsecutiveValues(point1Addr, int16(6))
+			point1MemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(point1Addr, int16(6))
 			if err != nil {
 				return err
 			}

--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -161,7 +161,7 @@ func newFastEcAddAssignNewXHint(slope, point0, point1 hinter.ResOperander) hinte
 			if err != nil {
 				return err
 			}
-			slopeMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(slopeAddr, int16(6))
+			slopeMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(slopeAddr, int16(3))
 			if err != nil {
 				return err
 			}
@@ -179,7 +179,7 @@ func newFastEcAddAssignNewXHint(slope, point0, point1 hinter.ResOperander) hinte
 			if err != nil {
 				return err
 			}
-			point1MemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(point1Addr, int16(6))
+			point1MemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(point1Addr, int16(3))
 			if err != nil {
 				return err
 			}
@@ -487,7 +487,7 @@ func newEcDoubleAssignNewXV1Hint(slope, point hinter.ResOperander) hinter.Hinter
 			if err != nil {
 				return err
 			}
-			slopeMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(slopeAddr, int16(6))
+			slopeMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(slopeAddr, int16(3))
 			if err != nil {
 				return err
 			}

--- a/pkg/hintrunner/zero/zerohint_signature.go
+++ b/pkg/hintrunner/zero/zerohint_signature.go
@@ -42,7 +42,7 @@ func newVerifyZeroHint(val, q hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			valMemoryValues, err := memory.InitializeEmptyMemory().GetConsecutiveValues(valAddr, int16(6))
+			valMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(valAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -177,7 +177,7 @@ func newGetPointFromXHint(xCube, v hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			xCubeMemoryValues, err := memory.InitializeEmptyMemory().GetConsecutiveValues(xCubeAddr, int16(6))
+			xCubeMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(xCubeAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -334,7 +334,7 @@ func newDivModNPackedDivmodV1Hint(a, b hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			aMemoryValues, err := memory.InitializeEmptyMemory().GetConsecutiveValues(aAddr, int16(6))
+			aMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(aAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -343,7 +343,7 @@ func newDivModNPackedDivmodV1Hint(a, b hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			bMemoryValues, err := memory.InitializeEmptyMemory().GetConsecutiveValues(bAddr, int16(6))
+			bMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(bAddr, int16(6))
 			if err != nil {
 				return err
 			}

--- a/pkg/hintrunner/zero/zerohint_signature.go
+++ b/pkg/hintrunner/zero/zerohint_signature.go
@@ -42,7 +42,7 @@ func newVerifyZeroHint(val, q hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			valMemoryValues, err := hinter.GetConsecutiveValues(vm, valAddr, int16(3))
+			valMemoryValues, err := memory.InitializeEmptyMemory().GetConsecutiveValues(valAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -177,7 +177,7 @@ func newGetPointFromXHint(xCube, v hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			xCubeMemoryValues, err := hinter.GetConsecutiveValues(vm, xCubeAddr, 3)
+			xCubeMemoryValues, err := memory.InitializeEmptyMemory().GetConsecutiveValues(xCubeAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -334,7 +334,7 @@ func newDivModNPackedDivmodV1Hint(a, b hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			aMemoryValues, err := hinter.GetConsecutiveValues(vm, aAddr, int16(3))
+			aMemoryValues, err := memory.InitializeEmptyMemory().GetConsecutiveValues(aAddr, int16(6))
 			if err != nil {
 				return err
 			}
@@ -343,7 +343,7 @@ func newDivModNPackedDivmodV1Hint(a, b hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			bMemoryValues, err := hinter.GetConsecutiveValues(vm, bAddr, int16(3))
+			bMemoryValues, err := memory.InitializeEmptyMemory().GetConsecutiveValues(bAddr, int16(6))
 			if err != nil {
 				return err
 			}

--- a/pkg/hintrunner/zero/zerohint_signature.go
+++ b/pkg/hintrunner/zero/zerohint_signature.go
@@ -42,7 +42,7 @@ func newVerifyZeroHint(val, q hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			valMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(valAddr, int16(6))
+			valMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(valAddr, int16(3))
 			if err != nil {
 				return err
 			}
@@ -177,7 +177,7 @@ func newGetPointFromXHint(xCube, v hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			xCubeMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(xCubeAddr, int16(6))
+			xCubeMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(xCubeAddr, int16(3))
 			if err != nil {
 				return err
 			}
@@ -334,7 +334,7 @@ func newDivModNPackedDivmodV1Hint(a, b hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			aMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(aAddr, int16(6))
+			aMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(aAddr, int16(3))
 			if err != nil {
 				return err
 			}
@@ -343,7 +343,7 @@ func newDivModNPackedDivmodV1Hint(a, b hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
-			bMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(bAddr, int16(6))
+			bMemoryValues, err := vm.Memory.GetConsecutiveMemoryValues(bAddr, int16(3))
 			if err != nil {
 				return err
 			}

--- a/pkg/hintrunner/zero/zerohint_utils_test.go
+++ b/pkg/hintrunner/zero/zerohint_utils_test.go
@@ -10,7 +10,6 @@ import (
 	runnerutil "github.com/NethermindEth/cairo-vm-go/pkg/hintrunner/utils"
 	"github.com/NethermindEth/cairo-vm-go/pkg/parsers/starknet"
 	"github.com/NethermindEth/cairo-vm-go/pkg/vm"
-	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
 	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 	"github.com/stretchr/testify/require"
@@ -67,7 +66,7 @@ func feltAdd(x, y *fp.Element) *fp.Element {
 
 func apValueEquals(expected *fp.Element) func(t *testing.T, ctx *hintTestContext) {
 	return func(t *testing.T, ctx *hintTestContext) {
-		actual := runnerutil.ReadFrom(ctx.vm, VM.ExecutionSegment, ctx.vm.Context.Ap)
+		actual := runnerutil.ReadFrom(ctx.vm, vm.ExecutionSegment, ctx.vm.Context.Ap)
 		actualFelt, err := actual.FieldElement()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/vm/memory/memory_value.go
+++ b/pkg/vm/memory/memory_value.go
@@ -315,3 +315,19 @@ func (mv *MemoryValue) Uint64() (uint64, error) {
 func (mv *MemoryValue) addrUnsafe() *MemoryAddress {
 	return (*MemoryAddress)(unsafe.Pointer(&mv.felt))
 }
+
+func (memory *Memory) GetConsecutiveValues(addr MemoryAddress, size int16) ([]MemoryValue, error) {
+	values := make([]MemoryValue, size)
+	for i := int16(0); i < size; i++ {
+		nAddr, err := addr.AddOffset(i)
+		if err != nil {
+			return nil, err
+		}
+		v, err := memory.ReadFromAddress(&nAddr)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = v
+	}
+	return values, nil
+}

--- a/pkg/vm/memory/memory_value.go
+++ b/pkg/vm/memory/memory_value.go
@@ -316,7 +316,7 @@ func (mv *MemoryValue) addrUnsafe() *MemoryAddress {
 	return (*MemoryAddress)(unsafe.Pointer(&mv.felt))
 }
 
-func (memory *Memory) GetConsecutiveValues(addr MemoryAddress, size int16) ([]MemoryValue, error) {
+func (memory *Memory) GetConsecutiveMemoryValues(addr MemoryAddress, size int16) ([]MemoryValue, error) {
 	values := make([]MemoryValue, size)
 	for i := int16(0); i < size; i++ {
 		nAddr, err := addr.AddOffset(i)


### PR DESCRIPTION
## What does this PR do?

- Moves the `GetConsecutiveValues` functionality from hinter package to memory package.
- Makes necessary changes to files that invoked `GetConsecutiveValues` to match new function location.

### Related Issue(s)?
- Resolves #384 