### PR TITLE
Fix how lastMemIndex is calculated in DecodeMemory

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -590,7 +590,7 @@ func DecodeTrace(content []byte) []Trace {
 const addrSize = 8
 const feltSize = 32
 
-// Encody the relocated memory in the (address, value) form
+// Encode the relocated memory in the (address, value) form
 // in a consecutive way
 func EncodeMemory(memory []*f.Element) []byte {
 	// Check non nil elements for optimal array size
@@ -623,12 +623,18 @@ func EncodeMemory(memory []*f.Element) []byte {
 	return content
 }
 
+// DecodeMemory decodes an encoded memory byte array back to a memory array of felts
 func DecodeMemory(content []byte) []*f.Element {
 	if len(content) == 0 {
 		return make([]*f.Element, 0)
 	}
 
 	// calculate the max memory index
+	// the content byte array has addresses and its associated value
+	// in a (address, value) form
+	// but the data isn't necessarily sorted by address,
+	// so we scan through the entire memory file, find the largest memory index
+	// and use it to initialize the memory array below
 	lastMemIndex := uint64(0)
 	for i := 0; i < len(content); i += addrSize + feltSize {
 		memIndex := binary.LittleEndian.Uint64(content[i : i+addrSize])

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -624,13 +624,23 @@ func EncodeMemory(memory []*f.Element) []byte {
 }
 
 func DecodeMemory(content []byte) []*f.Element {
+	if len(content) == 0 {
+		return make([]*f.Element, 0)
+	}
+
 	// calculate the max memory index
-	lastMemIndex := len(content) / (addrSize + feltSize)
+	lastMemIndex := uint64(0)
+	for i := 0; i < len(content); i += addrSize + feltSize {
+		memIndex := binary.LittleEndian.Uint64(content[i : i+addrSize])
+		if memIndex > lastMemIndex {
+			lastMemIndex = memIndex
+		}
+	}
 
 	// create the memory array with the same length as the max memory index
 	memory := make([]*f.Element, lastMemIndex+1)
 
-	// decode the encontent and store it in memory
+	// decode the content and store it in memory
 	for i := 0; i < len(content); i += addrSize + feltSize {
 		memIndex := binary.LittleEndian.Uint64(content[i : i+addrSize])
 		felt, err := f.LittleEndian.Element((*[32]byte)(content[i+addrSize : i+addrSize+feltSize]))

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -625,11 +625,10 @@ func EncodeMemory(memory []*f.Element) []byte {
 
 func DecodeMemory(content []byte) []*f.Element {
 	// calculate the max memory index
-	lastContentInd := len(content) - (addrSize + feltSize)
-	lasMemIndex := binary.LittleEndian.Uint64(content[lastContentInd : lastContentInd+addrSize])
+	lastMemIndex := len(content) / (addrSize + feltSize)
 
 	// create the memory array with the same length as the max memory index
-	memory := make([]*f.Element, lasMemIndex+1)
+	memory := make([]*f.Element, lastMemIndex+1)
 
 	// decode the encontent and store it in memory
 	for i := 0; i < len(content); i += addrSize + feltSize {


### PR DESCRIPTION
Previously the max memory index in a memory file was calculated assuming that the last address in the file would represent the highest index.

```
// calculate the max memory index
lastContentInd := len(content) - (addrSize + feltSize)
lastMemIndex := binary.LittleEndian.Uint64(content[lastContentInd : lastContentInd+addrSize])
```

But this is not always the case. The memory file generated by the python vm can have the addresses in the file written out of order. That means the last address in the file need not be the largest address.

This PR changes that logic. Now the code will iterate over all the addresses in the memory file and find the largest one before initialising the decoded memory array and populating it.

Related to https://github.com/NethermindEth/cairo-vm-go/issues/395