### PR TITLE
[bug]: implement correctly `UsortVerifyMultiplicityBody` hint

### DIFF
--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -195,7 +195,7 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return err
 			}
 
-			return ctx.ScopeManager.AssignVariable("last_pos", currentPos.Add(&currentPos, &utils.FeltOne))
+			return ctx.ScopeManager.AssignVariable("last_pos", *currentPos.Add(&currentPos, &utils.FeltOne))
 		},
 	}
 }

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -154,9 +154,9 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return err
 			}
 
-			positions, ok := positionsInterface.([]int64)
+			positions, ok := positionsInterface.([]fp.Element)
 			if !ok {
-				return fmt.Errorf("cannot cast positionsInterface to []int64")
+				return fmt.Errorf("cannot cast positionsInterface to []fp.Element")
 			}
 
 			currentPos, err := utils.Pop(&positions)
@@ -174,14 +174,15 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return err
 			}
 
-			lastPosInt, ok := lastPos.(int64)
+			lastPosFelt, ok := lastPos.(fp.Element)
 			if !ok {
-				return fmt.Errorf("cannot cast last_pos to int64")
+				return fmt.Errorf("cannot cast last_pos to felt")
 			}
 
 			// Calculate `next_item_index` memory value
-			newNextItemIndexValue := currentPos - lastPosInt
-			newNextItemIndexMemoryValue := memory.MemoryValueFromInt(newNextItemIndexValue)
+			var newNextItemIndexValue fp.Element
+			newNextItemIndexValue.Sub(&currentPos, &lastPosFelt)
+			newNextItemIndexMemoryValue := memory.MemoryValueFromFieldElement(&newNextItemIndexValue)
 
 			// Save `next_item_index` value in address
 			addrNextItemIndex, err := nextItemIndex.GetAddress(vm)
@@ -194,7 +195,7 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return err
 			}
 
-			return ctx.ScopeManager.AssignVariable("last_pos", int64(currentPos+1))
+			return ctx.ScopeManager.AssignVariable("last_pos", currentPos.Add(&currentPos, &utils.FeltOne))
 		},
 	}
 }

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -164,6 +164,11 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return err
 			}
 
+			err = ctx.ScopeManager.AssignVariable("positions", positions)
+			if err != nil {
+				return err
+			}
+
 			lastPos, err := ctx.ScopeManager.GetVariableValue("last_pos")
 			if err != nil {
 				return err

--- a/pkg/hintrunner/zero/zerohint_usort.go
+++ b/pkg/hintrunner/zero/zerohint_usort.go
@@ -159,21 +159,9 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return fmt.Errorf("cannot cast positionsInterface to []int64")
 			}
 
-			newCurrentPos, err := utils.Pop(&positions)
+			currentPos, err := utils.Pop(&positions)
 			if err != nil {
 				return err
-			}
-
-			// TODO : This is not correct, `newCurrentPos` should be used
-			// and there is not `current_pos` variable to retrieve in scope
-			currentPos, err := ctx.ScopeManager.GetVariableValue("current_pos")
-			if err != nil {
-				return err
-			}
-
-			currentPosInt, ok := currentPos.(int64)
-			if !ok {
-				return fmt.Errorf("cannot cast current_pos to int64")
 			}
 
 			lastPos, err := ctx.ScopeManager.GetVariableValue("last_pos")
@@ -187,7 +175,7 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 			}
 
 			// Calculate `next_item_index` memory value
-			newNextItemIndexValue := currentPosInt - lastPosInt
+			newNextItemIndexValue := currentPos - lastPosInt
 			newNextItemIndexMemoryValue := memory.MemoryValueFromInt(newNextItemIndexValue)
 
 			// Save `next_item_index` value in address
@@ -201,12 +189,7 @@ func newUsortVerifyMultiplicityBodyHint(nextItemIndex hinter.ResOperander) hinte
 				return err
 			}
 
-			// TODO : Only last_pos should be assigned in current scope
-			// Save `current_pos` and `last_pos` values in scope variables
-			return ctx.ScopeManager.AssignVariables(map[string]any{
-				"current_pos": newCurrentPos,
-				"last_pos":    int64(currentPosInt + 1),
-			})
+			return ctx.ScopeManager.AssignVariable("last_pos", int64(currentPos+1))
 		},
 	}
 }

--- a/pkg/hintrunner/zero/zerohint_usort_test.go
+++ b/pkg/hintrunner/zero/zerohint_usort_test.go
@@ -96,9 +96,8 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				ctxInit: func(ctx *hinter.HintRunnerContext) {
 					ctx.ScopeManager.EnterScope(map[string]any{
-						"positions":   []int64{8, 6, 4},
-						"current_pos": int64(2),
-						"last_pos":    int64(1),
+						"positions": []int64{8, 6, 4},
+						"last_pos":  int64(2),
 					})
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
@@ -106,11 +105,52 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"current_pos": int64(4),
-						"last_pos":    int64(3),
+						"last_pos": int64(5),
 					})(t, ctx)
 
-					varValueEquals("next_item_index", feltInt64(1))(t, ctx)
+					varValueEquals("next_item_index", feltInt64(2))(t, ctx)
+				},
+			},
+			{
+				operanders: []*hintOperander{
+					{Name: "next_item_index", Kind: uninitialized},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					ctx.ScopeManager.EnterScope(map[string]any{
+						"positions": []int64{90, 80, 70, 60, 50, 40, 30, 20, 10},
+						"last_pos":  int64(0),
+					})
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newUsortVerifyMultiplicityBodyHint(ctx.operanders["next_item_index"])
+				},
+				check: func(t *testing.T, ctx *hintTestContext) {
+					allVarValueInScopeEquals(map[string]any{
+						"last_pos": int64(11),
+					})(t, ctx)
+
+					varValueEquals("next_item_index", feltInt64(10))(t, ctx)
+				},
+			},
+			{
+				operanders: []*hintOperander{
+					{Name: "next_item_index", Kind: uninitialized},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					ctx.ScopeManager.EnterScope(map[string]any{
+						"positions": []int64{99, 91, 89, 84, 82, 79, 72, 71, 70, 64, 59},
+						"last_pos":  int64(56),
+					})
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newUsortVerifyMultiplicityBodyHint(ctx.operanders["next_item_index"])
+				},
+				check: func(t *testing.T, ctx *hintTestContext) {
+					allVarValueInScopeEquals(map[string]any{
+						"last_pos": int64(60),
+					})(t, ctx)
+
+					varValueEquals("next_item_index", feltInt64(3))(t, ctx)
 				},
 			},
 		},

--- a/pkg/hintrunner/zero/zerohint_usort_test.go
+++ b/pkg/hintrunner/zero/zerohint_usort_test.go
@@ -105,7 +105,7 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"last_pos": int64(5),
+						"last_pos": int64(5), "positions": []int64{8, 6},
 					})(t, ctx)
 
 					varValueEquals("next_item_index", feltInt64(2))(t, ctx)
@@ -126,7 +126,7 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"last_pos": int64(11),
+						"last_pos": int64(11), "positions": []int64{90, 80, 70, 60, 50, 40, 30, 20},
 					})(t, ctx)
 
 					varValueEquals("next_item_index", feltInt64(10))(t, ctx)
@@ -147,7 +147,7 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"last_pos": int64(60),
+						"last_pos": int64(60), "positions": []int64{99, 91, 89, 84, 82, 79, 72, 71, 70, 64},
 					})(t, ctx)
 
 					varValueEquals("next_item_index", feltInt64(3))(t, ctx)

--- a/pkg/hintrunner/zero/zerohint_usort_test.go
+++ b/pkg/hintrunner/zero/zerohint_usort_test.go
@@ -96,8 +96,8 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				ctxInit: func(ctx *hinter.HintRunnerContext) {
 					ctx.ScopeManager.EnterScope(map[string]any{
-						"positions": []int64{8, 6, 4},
-						"last_pos":  int64(2),
+						"positions": []fp.Element{*feltInt64(8), *feltInt64(6), *feltInt64(4)},
+						"last_pos":  *feltInt64(2),
 					})
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
@@ -105,7 +105,7 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"last_pos": int64(5), "positions": []int64{8, 6},
+						"last_pos": feltInt64(5), "positions": []fp.Element{*feltInt64(8), *feltInt64(6)},
 					})(t, ctx)
 
 					varValueEquals("next_item_index", feltInt64(2))(t, ctx)
@@ -117,8 +117,8 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				ctxInit: func(ctx *hinter.HintRunnerContext) {
 					ctx.ScopeManager.EnterScope(map[string]any{
-						"positions": []int64{90, 80, 70, 60, 50, 40, 30, 20, 10},
-						"last_pos":  int64(0),
+						"positions": []fp.Element{*feltInt64(90), *feltInt64(80), *feltInt64(70), *feltInt64(60), *feltInt64(50)},
+						"last_pos":  *feltInt64(0),
 					})
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
@@ -126,10 +126,10 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"last_pos": int64(11), "positions": []int64{90, 80, 70, 60, 50, 40, 30, 20},
+						"last_pos": feltInt64(51), "positions": []fp.Element{*feltInt64(90), *feltInt64(80), *feltInt64(70), *feltInt64(60)},
 					})(t, ctx)
 
-					varValueEquals("next_item_index", feltInt64(10))(t, ctx)
+					varValueEquals("next_item_index", feltInt64(50))(t, ctx)
 				},
 			},
 			{
@@ -138,8 +138,8 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				ctxInit: func(ctx *hinter.HintRunnerContext) {
 					ctx.ScopeManager.EnterScope(map[string]any{
-						"positions": []int64{99, 91, 89, 84, 82, 79, 72, 71, 70, 64, 59},
-						"last_pos":  int64(56),
+						"positions": []fp.Element{*feltInt64(87), *feltInt64(51), *feltInt64(43), *feltInt64(37)},
+						"last_pos":  *feltInt64(29),
 					})
 				},
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
@@ -147,10 +147,10 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"last_pos": int64(60), "positions": []int64{99, 91, 89, 84, 82, 79, 72, 71, 70, 64},
+						"last_pos": feltInt64(38), "positions": []fp.Element{*feltInt64(87), *feltInt64(51), *feltInt64(43)},
 					})(t, ctx)
 
-					varValueEquals("next_item_index", feltInt64(3))(t, ctx)
+					varValueEquals("next_item_index", feltInt64(8))(t, ctx)
 				},
 			},
 		},

--- a/pkg/hintrunner/zero/zerohint_usort_test.go
+++ b/pkg/hintrunner/zero/zerohint_usort_test.go
@@ -105,7 +105,7 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"last_pos": feltInt64(5), "positions": []fp.Element{*feltInt64(8), *feltInt64(6)},
+						"last_pos": *feltInt64(5), "positions": []fp.Element{*feltInt64(8), *feltInt64(6)},
 					})(t, ctx)
 
 					varValueEquals("next_item_index", feltInt64(2))(t, ctx)
@@ -126,7 +126,7 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"last_pos": feltInt64(51), "positions": []fp.Element{*feltInt64(90), *feltInt64(80), *feltInt64(70), *feltInt64(60)},
+						"last_pos": *feltInt64(51), "positions": []fp.Element{*feltInt64(90), *feltInt64(80), *feltInt64(70), *feltInt64(60)},
 					})(t, ctx)
 
 					varValueEquals("next_item_index", feltInt64(50))(t, ctx)
@@ -147,7 +147,7 @@ func TestZeroHintUsort(t *testing.T) {
 				},
 				check: func(t *testing.T, ctx *hintTestContext) {
 					allVarValueInScopeEquals(map[string]any{
-						"last_pos": feltInt64(38), "positions": []fp.Element{*feltInt64(87), *feltInt64(51), *feltInt64(43)},
+						"last_pos": *feltInt64(38), "positions": []fp.Element{*feltInt64(87), *feltInt64(51), *feltInt64(43)},
 					})(t, ctx)
 
 					varValueEquals("next_item_index", feltInt64(8))(t, ctx)

--- a/pkg/hintrunner/zero/zerohint_utils_test.go
+++ b/pkg/hintrunner/zero/zerohint_utils_test.go
@@ -164,19 +164,19 @@ func varValueInScopeEquals(varName string, expected any) func(t *testing.T, ctx 
 					t.Fatalf("%s scope value mismatch:\nhave: %v\nwant: %v", varName, value, expected)
 				}
 			}
-		case []int64:
-			{
-				valueArray := value.([]int64)
-				expectedArray := expected.([]int64)
-				if !reflect.DeepEqual(valueArray, expectedArray) {
-					t.Fatalf("%s scope value mismatch:\nhave: %v\nwant: %v", varName, value, expected)
-				}
-			}
 		case *fp.Element:
 			{
 				valueFelt := value.(*fp.Element)
 				expectedFelt := expected.(*fp.Element)
 				if valueFelt.Cmp(expectedFelt) != 0 {
+					t.Fatalf("%s scope value mismatch:\nhave: %v\nwant: %v", varName, value, expected)
+				}
+			}
+		case []fp.Element:
+			{
+				valueArray := value.([]fp.Element)
+				expectedArray := expected.([]fp.Element)
+				if !reflect.DeepEqual(valueArray, expectedArray) {
 					t.Fatalf("%s scope value mismatch:\nhave: %v\nwant: %v", varName, value, expected)
 				}
 			}

--- a/pkg/hintrunner/zero/zerohint_utils_test.go
+++ b/pkg/hintrunner/zero/zerohint_utils_test.go
@@ -2,6 +2,7 @@ package zero
 
 import (
 	"fmt"
+	"reflect"
 
 	"math/big"
 	"testing"
@@ -160,6 +161,14 @@ func varValueInScopeEquals(varName string, expected any) func(t *testing.T, ctx 
 				valueBig := value.(*big.Int)
 				expectedBig := expected.(*big.Int)
 				if valueBig.Cmp(expectedBig) != 0 {
+					t.Fatalf("%s scope value mismatch:\nhave: %v\nwant: %v", varName, value, expected)
+				}
+			}
+		case []int64:
+			{
+				valueArray := value.([]int64)
+				expectedArray := expected.([]int64)
+				if !reflect.DeepEqual(valueArray, expectedArray) {
 					t.Fatalf("%s scope value mismatch:\nhave: %v\nwant: %v", varName, value, expected)
 				}
 			}


### PR DESCRIPTION
Resolves #391 

This PR rectifies `UsortVerifyMultiplicityBody` hint previously wrongly implemented.
I also added more tests, always with a descending list as input (required). 

note that `current_pos` does not need to be assigned in scope , i also rectified this. `current_scope` is calculated for each iteration with `positions.pop()` and is not required in scope.
Also, i added a reassignement of `positions` in the scope because it was missing, `positions` needs to be updated in scope otherwise the array will ne be emptied in the recursive call, this will cause an infinite loop when calling usort
