### PR TITLE
feat: `EcDoubleAssignNewYV1` hint

### DIFF
--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -64,11 +64,12 @@ const (
 	// ------ Elliptic Curve hints related code ------
 	ecNegateCode            string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\ny = pack(ids.point.y, PRIME) % SECP_P\n# The modulo operation in python always returns a nonnegative number.\nvalue = (-y) % SECP_P"
 	nondetBigint3V1Code     string = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))"
-	fastEcAddAssignNewYCode string = "value = new_y = (slope * (x0 - new_x) - y0) % SECP_P"
 	fastEcAddAssignNewXCode string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nslope = pack(ids.slope, PRIME)\nx0 = pack(ids.point0.x, PRIME)\nx1 = pack(ids.point1.x, PRIME)\ny0 = pack(ids.point0.y, PRIME)\n\nvalue = new_x = (pow(slope, 2, SECP_P) - x0 - x1) % SECP_P"
+	fastEcAddAssignNewYCode string = "value = new_y = (slope * (x0 - new_x) - y0) % SECP_P"
 	ecDoubleSlopeV1Code     string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nfrom starkware.python.math_utils import ec_double_slope\n\n# Compute the slope.\nx = pack(ids.point.x, PRIME)\ny = pack(ids.point.y, PRIME)\nvalue = slope = ec_double_slope(point=(x, y), alpha=0, p=SECP_P)"
 	computeSlopeV1Code      string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nfrom starkware.python.math_utils import line_slope\n\n# Compute the slope.\nx0 = pack(ids.point0.x, PRIME)\ny0 = pack(ids.point0.y, PRIME)\nx1 = pack(ids.point1.x, PRIME)\ny1 = pack(ids.point1.y, PRIME)\nvalue = slope = line_slope(point1=(x0, y0), point2=(x1, y1), p=SECP_P)"
 	ecDoubleAssignNewXV1    string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nslope = pack(ids.slope, PRIME)\nx = pack(ids.point.x, PRIME)\ny = pack(ids.point.y, PRIME)\n\nvalue = new_x = (pow(slope, 2, SECP_P) - 2 * x) % SECP_P"
+	ecDoubleAssignNewYV1    string = "value = new_y = (slope * (x - new_x) - y) % SECP_P"
 
 	// ------ Signature hints related code ------
 	verifyECDSASignatureCode  string = "ecdsa_builtin.add_signature(ids.ecdsa_ptr.address_, (ids.signature_r, ids.signature_s))"

--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -125,16 +125,18 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createEcNegateHinter(resolver)
 	case nondetBigint3V1Code:
 		return createNondetBigint3V1Hinter(resolver)
-	case fastEcAddAssignNewYCode:
-		return createFastEcAddAssignNewYHinter()
 	case fastEcAddAssignNewXCode:
 		return createFastEcAddAssignNewXHinter(resolver)
+	case fastEcAddAssignNewYCode:
+		return createFastEcAddAssignNewYHinter()
 	case ecDoubleSlopeV1Code:
 		return createEcDoubleSlopeV1Hinter(resolver)
 	case computeSlopeV1Code:
 		return createComputeSlopeV1Hinter(resolver)
 	case ecDoubleAssignNewXV1:
 		return createEcDoubleAssignNewXV1Hinter(resolver)
+	case ecDoubleAssignNewYV1:
+		return createEcDoubleAssignNewYV1Hinter()
 		// Blake hints
 	case blake2sAddUint256BigendCode:
 		return createBlake2sAddUint256Hinter(resolver, true)

--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -284,6 +284,9 @@ func createFastEcAddAssignNewXHinter(resolver hintReferenceResolver) (hinter.Hin
 }
 
 // FastEcAddAssignNewY hint computes a new y-coordinate for fast elliptic curve addition
+// of two different points
+// This hint is ultimately used for either multiplying a point with an integer with `ec_mul_by_uint256`
+// Cairo function, or for adding two different points with `ec_add` Cairo function
 //
 // `newFastEcAddAssignNewYHint` doesn't take any operander as argument
 // This hint follows the execution of `FastEcAddAssignNewX` hint when computing the addition of two given points
@@ -533,6 +536,8 @@ func createEcDoubleAssignNewXV1Hinter(resolver hintReferenceResolver) (hinter.Hi
 
 // EcDoubleAssignNewYV1 hint computes a new y-coordinate when doubling a point
 // on an elliptic curve
+// This hint is ultimately used for either multiplying a point with an integer with `ec_mul_by_uint256`
+// Cairo function, or for adding a given point to itself with `ec_add` Cairo function
 //
 // `newEcDoubleAssignNewYV1Hint` doesn't take any operander as argument
 // This hint follows the execution of `EcDoubleAssignNewXV1` hint when doubling a point
@@ -543,7 +548,7 @@ func newEcDoubleAssignNewYV1Hint() hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "EcDoubleAssignNewYV1",
 		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
-			//> value = new_y = (slope * (x - new_x) - y) % SECP_P
+			//> value = new_y = (slope * (x - new_x) - y) % SECP256R1_P
 
 			slopeBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("slope")
 			if err != nil {

--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -317,14 +317,7 @@ func newFastEcAddAssignNewYHint() hinter.Hinter {
 				return err
 			}
 
-			new_yBig := new(big.Int)
-			new_yBig.Sub(x0Big, new_xBig)
-			new_yBig.Mul(new_yBig, slopeBig)
-			new_yBig.Sub(new_yBig, y0Big)
-			new_yBig.Mod(new_yBig, secPBig)
-
-			valueBig := new(big.Int)
-			valueBig.Set(new_yBig)
+			valueBig := ComputeYCoordinate(slopeBig, x0Big, new_xBig, y0Big, secPBig)
 
 			return ctx.ScopeManager.AssignVariables(map[string]any{"value": valueBig})
 		},
@@ -573,14 +566,7 @@ func newEcDoubleAssignNewYV1Hint() hinter.Hinter {
 				return err
 			}
 
-			new_yBig := new(big.Int)
-			new_yBig.Sub(xBig, new_xBig)
-			new_yBig.Mul(new_yBig, slopeBig)
-			new_yBig.Sub(new_yBig, yBig)
-			new_yBig.Mod(new_yBig, secPBig)
-
-			valueBig := new(big.Int)
-			valueBig.Set(new_yBig)
+			valueBig := ComputeYCoordinate(slopeBig, xBig, new_xBig, yBig, secPBig)
 
 			return ctx.ScopeManager.AssignVariables(map[string]any{"value": valueBig})
 		},

--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -136,58 +136,6 @@ func createNondetBigint3V1Hinter(resolver hintReferenceResolver) (hinter.Hinter,
 	return newNondetBigint3V1Hint(res), nil
 }
 
-// FastEcAddAssignNewY hint computes a new y-coordinate for fast elliptic curve addition
-//
-// `newFastEcAddAssignNewYHint` doesn't take any operander as argument
-// This hint follows the execution of `FastEcAddAssignNewX` hint when computing the addition of two given points
-// This is why all variables are already accessible in the current scope
-//
-// `newFastEcAddAssignNewYHint` assigns the new y-coordinate as `value` in the current scope
-func newFastEcAddAssignNewYHint() hinter.Hinter {
-	return &GenericZeroHinter{
-		Name: "FastEcAddAssignNewY",
-		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
-			//> value = new_y = (slope * (x0 - new_x) - y0) % SECP_P
-
-			slopeBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("slope")
-			if err != nil {
-				return err
-			}
-			x0Big, err := ctx.ScopeManager.GetVariableValueAsBigInt("x0")
-			if err != nil {
-				return err
-			}
-			new_xBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("new_x")
-			if err != nil {
-				return err
-			}
-			y0Big, err := ctx.ScopeManager.GetVariableValueAsBigInt("y0")
-			if err != nil {
-				return err
-			}
-			secPBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("SECP_P")
-			if err != nil {
-				return err
-			}
-
-			new_yBig := new(big.Int)
-			new_yBig.Sub(x0Big, new_xBig)
-			new_yBig.Mul(new_yBig, slopeBig)
-			new_yBig.Sub(new_yBig, y0Big)
-			new_yBig.Mod(new_yBig, secPBig)
-
-			valueBig := new(big.Int)
-			valueBig.Set(new_yBig)
-
-			return ctx.ScopeManager.AssignVariables(map[string]any{"value": valueBig})
-		},
-	}
-}
-
-func createFastEcAddAssignNewYHinter() (hinter.Hinter, error) {
-	return newFastEcAddAssignNewYHint(), nil
-}
-
 // FastEcAddAssignNewX hint computes a new x-coordinate for fast elliptic curve addition
 //
 // `newFastEcAddAssignNewXHint` takes 3 operanders as arguments
@@ -333,6 +281,58 @@ func createFastEcAddAssignNewXHinter(resolver hintReferenceResolver) (hinter.Hin
 	}
 
 	return newFastEcAddAssignNewXHint(slope, point0, point1), nil
+}
+
+// FastEcAddAssignNewY hint computes a new y-coordinate for fast elliptic curve addition
+//
+// `newFastEcAddAssignNewYHint` doesn't take any operander as argument
+// This hint follows the execution of `FastEcAddAssignNewX` hint when computing the addition of two given points
+// This is why all variables are already accessible in the current scope
+//
+// `newFastEcAddAssignNewYHint` assigns the new y-coordinate as `value` in the current scope
+func newFastEcAddAssignNewYHint() hinter.Hinter {
+	return &GenericZeroHinter{
+		Name: "FastEcAddAssignNewY",
+		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
+			//> value = new_y = (slope * (x0 - new_x) - y0) % SECP_P
+
+			slopeBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("slope")
+			if err != nil {
+				return err
+			}
+			x0Big, err := ctx.ScopeManager.GetVariableValueAsBigInt("x0")
+			if err != nil {
+				return err
+			}
+			new_xBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("new_x")
+			if err != nil {
+				return err
+			}
+			y0Big, err := ctx.ScopeManager.GetVariableValueAsBigInt("y0")
+			if err != nil {
+				return err
+			}
+			secPBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("SECP_P")
+			if err != nil {
+				return err
+			}
+
+			new_yBig := new(big.Int)
+			new_yBig.Sub(x0Big, new_xBig)
+			new_yBig.Mul(new_yBig, slopeBig)
+			new_yBig.Sub(new_yBig, y0Big)
+			new_yBig.Mod(new_yBig, secPBig)
+
+			valueBig := new(big.Int)
+			valueBig.Set(new_yBig)
+
+			return ctx.ScopeManager.AssignVariables(map[string]any{"value": valueBig})
+		},
+	}
+}
+
+func createFastEcAddAssignNewYHinter() (hinter.Hinter, error) {
+	return newFastEcAddAssignNewYHint(), nil
 }
 
 // EcDoubleSlopeV1 hint computes the slope for doubling a point on an elliptic curve
@@ -536,6 +536,59 @@ func createEcDoubleAssignNewXV1Hinter(resolver hintReferenceResolver) (hinter.Hi
 	}
 
 	return newEcDoubleAssignNewXV1Hint(slope, point), nil
+}
+
+// EcDoubleAssignNewYV1 hint computes a new y-coordinate when doubling a point
+// on an elliptic curve
+//
+// `newEcDoubleAssignNewYV1Hint` doesn't take any operander as argument
+// This hint follows the execution of `EcDoubleAssignNewXV1` hint when doubling a point
+// This is why all variables are already accessible in the current scope
+//
+// `newEcDoubleAssignNewYV1Hint` assigns the new y-coordinate as `value` in the current scope
+func newEcDoubleAssignNewYV1Hint() hinter.Hinter {
+	return &GenericZeroHinter{
+		Name: "EcDoubleAssignNewYV1",
+		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
+			//> value = new_y = (slope * (x - new_x) - y) % SECP_P
+
+			slopeBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("slope")
+			if err != nil {
+				return err
+			}
+			xBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("x")
+			if err != nil {
+				return err
+			}
+			new_xBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("new_x")
+			if err != nil {
+				return err
+			}
+			yBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("y")
+			if err != nil {
+				return err
+			}
+			secPBig, err := ctx.ScopeManager.GetVariableValueAsBigInt("SECP_P")
+			if err != nil {
+				return err
+			}
+
+			new_yBig := new(big.Int)
+			new_yBig.Sub(xBig, new_xBig)
+			new_yBig.Mul(new_yBig, slopeBig)
+			new_yBig.Sub(new_yBig, yBig)
+			new_yBig.Mod(new_yBig, secPBig)
+
+			valueBig := new(big.Int)
+			valueBig.Set(new_yBig)
+
+			return ctx.ScopeManager.AssignVariables(map[string]any{"value": valueBig})
+		},
+	}
+}
+
+func createEcDoubleAssignNewYV1Hinter() (hinter.Hinter, error) {
+	return newEcDoubleAssignNewYV1Hint(), nil
 }
 
 // ComputeSlopeV1 hint computes the slope between two points on an elliptic curve

--- a/pkg/hintrunner/zero/zerohint_ec_test.go
+++ b/pkg/hintrunner/zero/zerohint_ec_test.go
@@ -345,72 +345,6 @@ func TestZeroHintEc(t *testing.T) {
 				check: consecutiveVarValueEquals("res", []*fp.Element{feltString("2"), feltString("2"), &utils.FeltZero}),
 			},
 		},
-		"FastEcAddAssignNewY": {
-			{
-				operanders: []*hintOperander{},
-				ctxInit: func(ctx *hinter.HintRunnerContext) {
-					slopeBig := big.NewInt(100)
-					x0Big := big.NewInt(20)
-					new_xBig := big.NewInt(10)
-					y0Big := big.NewInt(10)
-					secPBig, _ := secp_utils.GetSecPBig()
-
-					err := ctx.ScopeManager.AssignVariables(map[string]any{"slope": slopeBig, "x0": x0Big, "new_x": new_xBig, "y0": y0Big, "SECP_P": &secPBig})
-					if err != nil {
-						t.Fatal(err)
-					}
-				},
-				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newFastEcAddAssignNewYHint()
-				},
-				check: allVarValueInScopeEquals(map[string]any{
-					"value": big.NewInt(990),
-				}),
-			},
-			{
-				operanders: []*hintOperander{},
-				ctxInit: func(ctx *hinter.HintRunnerContext) {
-					slopeBig := big.NewInt(0)
-					x0Big := big.NewInt(20)
-					new_xBig := big.NewInt(10)
-					y0Big := big.NewInt(10)
-					secPBig, _ := secp_utils.GetSecPBig()
-
-					err := ctx.ScopeManager.AssignVariables(map[string]any{"slope": slopeBig, "x0": x0Big, "new_x": new_xBig, "y0": y0Big, "SECP_P": &secPBig})
-					if err != nil {
-						t.Fatal(err)
-					}
-				},
-				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newFastEcAddAssignNewYHint()
-				},
-				check: allVarValueInScopeEquals(map[string]any{
-					"value": bigIntString("115792089237316195423570985008687907853269984665640564039457584007908834671653", 10),
-				}),
-			},
-			{
-				operanders: []*hintOperander{},
-				ctxInit: func(ctx *hinter.HintRunnerContext) {
-					// GetSecPBig() + 20
-					slopeBig := bigIntString("115792089237316195423570985008687907853269984665640564039457584007908834671683", 10)
-					x0Big := big.NewInt(200)
-					new_xBig := big.NewInt(199)
-					y0Big := big.NewInt(20)
-					secPBig, _ := secp_utils.GetSecPBig()
-
-					err := ctx.ScopeManager.AssignVariables(map[string]any{"slope": slopeBig, "x0": x0Big, "new_x": new_xBig, "y0": y0Big, "SECP_P": &secPBig})
-					if err != nil {
-						t.Fatal(err)
-					}
-				},
-				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
-					return newFastEcAddAssignNewYHint()
-				},
-				check: allVarValueInScopeEquals(map[string]any{
-					"value": big.NewInt(0),
-				}),
-			},
-		},
 		"FastEcAddAssignNewX": {
 			{
 				operanders: []*hintOperander{
@@ -499,6 +433,72 @@ func TestZeroHintEc(t *testing.T) {
 					"y0":    bigIntString("-20441714640463444415550039378657358828977094550744864608392924301285287608509921726516187492362679433566942659569", 10),
 					"value": bigIntString("30230181511926491618309110200401529297651013854327841200453332701540948849717", 10),
 					"new_x": bigIntString("30230181511926491618309110200401529297651013854327841200453332701540948849717", 10),
+				}),
+			},
+		},
+		"FastEcAddAssignNewY": {
+			{
+				operanders: []*hintOperander{},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					slopeBig := big.NewInt(100)
+					x0Big := big.NewInt(20)
+					new_xBig := big.NewInt(10)
+					y0Big := big.NewInt(10)
+					secPBig, _ := secp_utils.GetSecPBig()
+
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"slope": slopeBig, "x0": x0Big, "new_x": new_xBig, "y0": y0Big, "SECP_P": &secPBig})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newFastEcAddAssignNewYHint()
+				},
+				check: allVarValueInScopeEquals(map[string]any{
+					"value": big.NewInt(990),
+				}),
+			},
+			{
+				operanders: []*hintOperander{},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					slopeBig := big.NewInt(0)
+					x0Big := big.NewInt(20)
+					new_xBig := big.NewInt(10)
+					y0Big := big.NewInt(10)
+					secPBig, _ := secp_utils.GetSecPBig()
+
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"slope": slopeBig, "x0": x0Big, "new_x": new_xBig, "y0": y0Big, "SECP_P": &secPBig})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newFastEcAddAssignNewYHint()
+				},
+				check: allVarValueInScopeEquals(map[string]any{
+					"value": bigIntString("115792089237316195423570985008687907853269984665640564039457584007908834671653", 10),
+				}),
+			},
+			{
+				operanders: []*hintOperander{},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					// GetSecPBig() + 20
+					slopeBig := bigIntString("115792089237316195423570985008687907853269984665640564039457584007908834671683", 10)
+					x0Big := big.NewInt(200)
+					new_xBig := big.NewInt(199)
+					y0Big := big.NewInt(20)
+					secPBig, _ := secp_utils.GetSecPBig()
+
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"slope": slopeBig, "x0": x0Big, "new_x": new_xBig, "y0": y0Big, "SECP_P": &secPBig})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newFastEcAddAssignNewYHint()
+				},
+				check: allVarValueInScopeEquals(map[string]any{
+					"value": big.NewInt(0),
 				}),
 			},
 		},
@@ -639,6 +639,72 @@ func TestZeroHintEc(t *testing.T) {
 					"value": bigIntString("30230181511926491618309110200401529297651013854327841200453332701540948849717", 10),
 					"slope": bigIntString("-20441714640463444415550039378657358828977094550744864608392924301285287608509921726516187492362679433566942659569", 10),
 					"new_x": bigIntString("30230181511926491618309110200401529297651013854327841200453332701540948849717", 10),
+				}),
+			},
+		},
+		"EcDoubleAssignNewYV1": {
+			{
+				operanders: []*hintOperander{},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					slopeBig := big.NewInt(100)
+					xBig := big.NewInt(20)
+					new_xBig := big.NewInt(10)
+					yBig := big.NewInt(10)
+					secPBig, _ := secp_utils.GetSecPBig()
+
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"slope": slopeBig, "x": xBig, "new_x": new_xBig, "y": yBig, "SECP_P": &secPBig})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newEcDoubleAssignNewYV1Hint()
+				},
+				check: allVarValueInScopeEquals(map[string]any{
+					"value": big.NewInt(990),
+				}),
+			},
+			{
+				operanders: []*hintOperander{},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					slopeBig := big.NewInt(0)
+					xBig := big.NewInt(20)
+					new_xBig := big.NewInt(10)
+					yBig := big.NewInt(10)
+					secPBig, _ := secp_utils.GetSecPBig()
+
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"slope": slopeBig, "x": xBig, "new_x": new_xBig, "y": yBig, "SECP_P": &secPBig})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newEcDoubleAssignNewYV1Hint()
+				},
+				check: allVarValueInScopeEquals(map[string]any{
+					"value": bigIntString("115792089237316195423570985008687907853269984665640564039457584007908834671653", 10),
+				}),
+			},
+			{
+				operanders: []*hintOperander{},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					// GetSecPBig() + 20
+					slopeBig := bigIntString("115792089237316195423570985008687907853269984665640564039457584007908834671683", 10)
+					xBig := big.NewInt(200)
+					new_xBig := big.NewInt(199)
+					yBig := big.NewInt(20)
+					secPBig, _ := secp_utils.GetSecPBig()
+
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"slope": slopeBig, "x": xBig, "new_x": new_xBig, "y": yBig, "SECP_P": &secPBig})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newEcDoubleAssignNewYV1Hint()
+				},
+				check: allVarValueInScopeEquals(map[string]any{
+					"value": big.NewInt(0),
 				}),
 			},
 		},

--- a/pkg/hintrunner/zero/zerohint_utils.go
+++ b/pkg/hintrunner/zero/zerohint_utils.go
@@ -48,6 +48,12 @@ func GetUint256AsFelts(vm *VM.VirtualMachine, ref hinter.ResOperander) (*fp.Elem
 	return low, high, nil
 }
 
+// This helper function is used in FastEcAddAssignNewY and
+// EcDoubleAssignNewYV1 hints to compute the y-coordinate of
+// a point on an elliptic curve
+//
+// ComputeYCoordinate returns `valueBig` which is the result of
+// the computation: (slope * (x - new_x) - y) % SECP_P
 func ComputeYCoordinate(slopeBig *big.Int, xBig *big.Int, new_xBig *big.Int, yBig *big.Int, secPBig *big.Int) *big.Int {
 	new_yBig := new(big.Int)
 	new_yBig.Sub(xBig, new_xBig)

--- a/pkg/hintrunner/zero/zerohint_utils.go
+++ b/pkg/hintrunner/zero/zerohint_utils.go
@@ -1,6 +1,8 @@
 package zero
 
 import (
+	"math/big"
+
 	"github.com/NethermindEth/cairo-vm-go/pkg/hintrunner/hinter"
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
@@ -44,4 +46,17 @@ func GetUint256AsFelts(vm *VM.VirtualMachine, ref hinter.ResOperander) (*fp.Elem
 	}
 
 	return low, high, nil
+}
+
+func ComputeYCoordinate(slopeBig *big.Int, xBig *big.Int, new_xBig *big.Int, yBig *big.Int, secPBig *big.Int) *big.Int {
+	new_yBig := new(big.Int)
+	new_yBig.Sub(xBig, new_xBig)
+	new_yBig.Mul(new_yBig, slopeBig)
+	new_yBig.Sub(new_yBig, yBig)
+	new_yBig.Mod(new_yBig, secPBig)
+
+	valueBig := new(big.Int)
+	valueBig.Set(new_yBig)
+
+	return valueBig
 }


### PR DESCRIPTION
Resolves #386 

@cicr99  as we discussed, i made a refactoring of `FastEcAddAssignNewY` and created a helper function `ComputeYCoordinate` so that both `EcDoubleAssignNewYV1` and `FastEcAddAssignNewY` use the same method.