### PR TITLE
Add description for `ReduceV1` hint

### DIFF
--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -420,7 +420,7 @@ func createEcDoubleSlopeV1Hinter(resolver hintReferenceResolver) (hinter.Hinter,
 // `newReduceV1Hint` takes 1 operander as argument
 //   - `x` is the packed value to be reduced
 //
-// `newReduceV1Hint` assigns the `slope` result as `value` in the current scope
+// `newReduceV1Hint` assigns the result as `value` in the current scope
 func newReduceV1Hint(x hinter.ResOperander) hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "ReduceV1",

--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -415,9 +415,15 @@ func createEcDoubleSlopeV1Hinter(resolver hintReferenceResolver) (hinter.Hinter,
 	return newEcDoubleSlopeV1Hint(point), nil
 }
 
+// ReduceV1 hint reduces a packed value modulo the SECP256R1 prime
+//
+// `newReduceV1Hint` takes 1 operander as argument
+//   - `x` is the packed value to be reduced
+//
+// `newReduceV1Hint` assigns the `slope` result as `value` in the current scope
 func newReduceV1Hint(x hinter.ResOperander) hinter.Hinter {
 	return &GenericZeroHinter{
-		Name: "reduceV1",
+		Name: "ReduceV1",
 		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
 			//> from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
 			//> value = pack(ids.x, PRIME) % SECP_P
@@ -426,6 +432,7 @@ func newReduceV1Hint(x hinter.ResOperander) hinter.Hinter {
 			if !ok {
 				return fmt.Errorf("GetSecPBig failed")
 			}
+
 			xAddr, err := x.GetAddress(vm)
 			if err != nil {
 				return err
@@ -435,6 +442,7 @@ func newReduceV1Hint(x hinter.ResOperander) hinter.Hinter {
 			if err != nil {
 				return err
 			}
+
 			var xValues [3]*fp.Element
 			for i := 0; i < 3; i++ {
 				xValue, err := xMemoryValues[i].FieldElement()
@@ -443,12 +451,15 @@ func newReduceV1Hint(x hinter.ResOperander) hinter.Hinter {
 				}
 				xValues[i] = xValue
 			}
+
 			xBig, err := secp_utils.SecPPacked(xValues)
 			if err != nil {
 				return err
 			}
+
 			xBig.Mod(&xBig, &secPBig)
 			valueBigIntPtr := new(big.Int).Set(&xBig)
+
 			return ctx.ScopeManager.AssignVariable("value", valueBigIntPtr)
 		},
 	}
@@ -459,6 +470,7 @@ func createReduceV1Hinter(resolver hintReferenceResolver) (hinter.Hinter, error)
 	if err != nil {
 		return nil, err
 	}
+
 	return newReduceV1Hint(x), nil
 }
 


### PR DESCRIPTION
There was missing description for `ReduceV1` hint that was just merged, this PR addresses this