### PR TITLE
feat: `SquashDictInnerUsedAccessesAssert` hint

### DIFF
--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -110,7 +110,7 @@ const (
 
 	// ------ Dictionaries hints related code ------
 	squashDictInnerAssertLenKeys      string = "assert len(keys) == 0"
-  squashDictInnerLenAssert          string = "assert len(current_access_indices) == 0"
+	squashDictInnerLenAssert          string = "assert len(current_access_indices) == 0"
 	squashDictInnerNextKey            string = "assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()"
 	squashDictInnerUsedAccessesAssert string = "assert ids.n_used_accesses == len(access_indices[key])"
 

--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -109,9 +109,9 @@ const (
 	keccakWriteArgs string = "segments.write_arg(ids.inputs, [ids.low % 2 ** 64, ids.low // 2 ** 64])\nsegments.write_arg(ids.inputs + 2, [ids.high % 2 ** 64, ids.high // 2 ** 64])"
 
 	// ------ Dictionaries hints related code ------
-	squashDictInnerAssertLenKeys string = "assert len(keys) == 0"
-	squashDictInnerNextKey       string = "assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()"
-
+	squashDictInnerAssertLenKeys      string = "assert len(keys) == 0"
+	squashDictInnerNextKey            string = "assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()"
+	squashDictInnerUsedAccessesAssert string = "assert ids.n_used_accesses == len(access_indices[key])"
 	// ------ Other hints related code ------
 	allocSegmentCode     string = "memory[ap] = segments.add()"
 	memcpyEnterScopeCode string = "vm_enter_scope({'n': ids.len})"

--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -109,12 +109,12 @@ const (
 	keccakWriteArgs string = "segments.write_arg(ids.inputs, [ids.low % 2 ** 64, ids.low // 2 ** 64])\nsegments.write_arg(ids.inputs + 2, [ids.high % 2 ** 64, ids.high // 2 ** 64])"
 
 	// ------ Dictionaries hints related code ------
-	defaultDictNewCode           string = "if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_default_dict(segments, ids.default_value)"
-	squashDictInnerAssertLenKeys string = "assert len(keys) == 0"
-	squashDictInnerContinueLoop  string = "ids.loop_temps.should_continue = 1 if current_access_indices else 0"
-	squashDictInnerLenAssert     string = "assert len(current_access_indices) == 0"
-	squashDictInnerNextKey       string = "assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()"
-  squashDictInnerUsedAccessesAssert string = "assert ids.n_used_accesses == len(access_indices[key])"
+	defaultDictNewCode                string = "if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_default_dict(segments, ids.default_value)"
+	squashDictInnerAssertLenKeys      string = "assert len(keys) == 0"
+	squashDictInnerContinueLoop       string = "ids.loop_temps.should_continue = 1 if current_access_indices else 0"
+	squashDictInnerLenAssert          string = "assert len(current_access_indices) == 0"
+	squashDictInnerNextKey            string = "assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()"
+	squashDictInnerUsedAccessesAssert string = "assert ids.n_used_accesses == len(access_indices[key])"
 
 	// ------ Other hints related code ------
 	allocSegmentCode     string = "memory[ap] = segments.add()"

--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -163,6 +163,8 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createSquashDictInnerAssertLenKeysHinter()
 	case squashDictInnerNextKey:
 		return createSquashDictInnerNextKeyHinter(resolver)
+	case squashDictInnerUsedAccessesAssert:
+		return createSquashDictInnerUsedAccessesAssertHinter(resolver)
 		// Other hints
 	case allocSegmentCode:
 		return createAllocSegmentHinter()

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -145,14 +145,20 @@ func newSquashDictInnerUsedAccessesAssertHint(nUsedAccesses hinter.ResOperander)
 				return err
 			}
 
-			access_indices := access_indices_.(map[fp.Element][]fp.Element)
+			access_indices, ok := access_indices_.(map[fp.Element][]fp.Element)
+			if !ok {
+				return fmt.Errorf("cannot cast access_indices_ to a mapping of felts")
+			}
 
 			key_, err := ctx.ScopeManager.GetVariableValue("key")
 			if err != nil {
 				return err
 			}
 
-			key := key_.(fp.Element)
+			key, ok := key_.(fp.Element)
+			if !ok {
+				return fmt.Errorf("cannot cast key_ to felt")
+			}
 
 			accessIndicesAtKey := uint64(len(access_indices[key]))
 
@@ -162,7 +168,7 @@ func newSquashDictInnerUsedAccessesAssertHint(nUsedAccesses hinter.ResOperander)
 			}
 
 			if accessIndicesAtKey != nUsedAccessesField {
-				return fmt.Errorf("assertion ids.n_used_accesses == len(access_indices[key] failed")
+				return fmt.Errorf("assertion ids.n_used_accesses == len(access_indices[key]) failed")
 			}
 
 			return nil

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -160,14 +160,14 @@ func newSquashDictInnerUsedAccessesAssertHint(nUsedAccesses hinter.ResOperander)
 				return fmt.Errorf("cannot cast key_ to felt")
 			}
 
-			accessIndicesAtKey := uint64(len(access_indices[key]))
+			accessIndicesAtKeyLen := uint64(len(access_indices[key]))
 
 			nUsedAccesses, err := hinter.ResolveAsUint64(vm, nUsedAccesses)
 			if err != nil {
 				return err
 			}
 
-			if accessIndicesAtKey != nUsedAccesses {
+			if accessIndicesAtKeyLen != nUsedAccesses {
 				return fmt.Errorf("assertion ids.n_used_accesses == len(access_indices[key]) failed")
 			}
 

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -96,7 +96,7 @@ func createSquashDictInnerNextKeyHinter(resolver hintReferenceResolver) (hinter.
 }
 
 // SquashDictInnerUsedAccessesAssert hint checks that `n_used_accesses` Cairo local variable
-// is equal to the the number of used accesses for a key during squashing
+// is equal to the the number of used accesses for a key during dictionary squashing
 //
 // `newSquashDictInnerUsedAccessesAssertHint` takes one operander as argument
 //   - `nUsedAccesses` represents the number of used accesses for a given key

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -162,12 +162,12 @@ func newSquashDictInnerUsedAccessesAssertHint(nUsedAccesses hinter.ResOperander)
 
 			accessIndicesAtKey := uint64(len(access_indices[key]))
 
-			nUsedAccessesField, err := hinter.ResolveAsUint64(vm, nUsedAccesses)
+			nUsedAccesses, err := hinter.ResolveAsUint64(vm, nUsedAccesses)
 			if err != nil {
 				return err
 			}
 
-			if accessIndicesAtKey != nUsedAccessesField {
+			if accessIndicesAtKey != nUsedAccesses {
 				return fmt.Errorf("assertion ids.n_used_accesses == len(access_indices[key]) failed")
 			}
 

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -40,12 +40,12 @@ func createSquashDictInnerAssertLenKeysHinter() (hinter.Hinter, error) {
 	return newSquashDictInnerAssertLenKeysHint(), nil
 }
 
-// SquashDictInnerAssertLenKeys hint asserts the length of the current
+// SquashDictInnerLenAssert hint asserts the length of the current
 // access indices for a given key is zero
 // `current_access_indices` is a reversed order list of access indices
 // for a given key, i.e., `sorted(access_indices[key])[::-1]`
 //
-// `newSquashDictInnerAssertLenKeysHint` doesn't take any operander as argument
+// `newSquashDictInnerLenAssertHint` doesn't take any operander as argument
 // and retrieves `current_access_indices` value from the current scope
 func newSquashDictInnerLenAssertHint() hinter.Hinter {
 	return &GenericZeroHinter{

--- a/pkg/hintrunner/zero/zerohint_dictionaries_test.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries_test.go
@@ -147,7 +147,7 @@ func TestZeroHintDictionaries(t *testing.T) {
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
 					return newSquashDictInnerUsedAccessesAssertHint(ctx.operanders["n_used_accesses"])
 				},
-				errCheck: errorTextContains("assertion ids.n_used_accesses == len(access_indices[key] failed"),
+				errCheck: errorTextContains("assertion ids.n_used_accesses == len(access_indices[key]) failed"),
 			},
 			{
 				operanders: []*hintOperander{
@@ -177,7 +177,7 @@ func TestZeroHintDictionaries(t *testing.T) {
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
 					return newSquashDictInnerUsedAccessesAssertHint(ctx.operanders["n_used_accesses"])
 				},
-				errCheck: errorTextContains("assertion ids.n_used_accesses == len(access_indices[key] failed"),
+				errCheck: errorTextContains("assertion ids.n_used_accesses == len(access_indices[key]) failed"),
 			},
 		},
 	})

--- a/pkg/hintrunner/zero/zerohint_dictionaries_test.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries_test.go
@@ -90,5 +90,67 @@ func TestZeroHintDictionaries(t *testing.T) {
 				},
 			},
 		},
+		"SquashDictInnerUsedAccessesAssert": {
+			{
+				operanders: []*hintOperander{
+					{Name: "n_used_accesses", Kind: apRelative, Value: feltInt64(0)},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"access_indices": map[fp.Element][]fp.Element{*feltUint64(0): {}, *feltUint64(1): {*feltUint64(1), *feltUint64(2), *feltUint64(3)}}, "key": *feltUint64(0)})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSquashDictInnerUsedAccessesAssertHint(ctx.operanders["n_used_accesses"])
+				},
+				check: func(t *testing.T, ctx *hintTestContext) {},
+			},
+			{
+				operanders: []*hintOperander{
+					{Name: "n_used_accesses", Kind: apRelative, Value: feltInt64(0)},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"access_indices": map[fp.Element][]fp.Element{*feltUint64(0): {}, *feltUint64(1): {*feltUint64(1), *feltUint64(2), *feltUint64(3)}}, "key": *feltUint64(1)})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSquashDictInnerUsedAccessesAssertHint(ctx.operanders["n_used_accesses"])
+				},
+				errCheck: errorTextContains("assertion ids.n_used_accesses == len(access_indices[key] failed"),
+			},
+			{
+				operanders: []*hintOperander{
+					{Name: "n_used_accesses", Kind: apRelative, Value: feltInt64(3)},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"access_indices": map[fp.Element][]fp.Element{*feltUint64(0): {}, *feltUint64(1): {*feltUint64(1), *feltUint64(2), *feltUint64(3)}}, "key": *feltUint64(1)})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSquashDictInnerUsedAccessesAssertHint(ctx.operanders["n_used_accesses"])
+				},
+				check: func(t *testing.T, ctx *hintTestContext) {},
+			},
+			{
+				operanders: []*hintOperander{
+					{Name: "n_used_accesses", Kind: apRelative, Value: feltInt64(3)},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					err := ctx.ScopeManager.AssignVariables(map[string]any{"access_indices": map[fp.Element][]fp.Element{*feltUint64(0): {}, *feltUint64(1): {*feltUint64(1), *feltUint64(2), *feltUint64(3)}}, "key": *feltUint64(0)})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSquashDictInnerUsedAccessesAssertHint(ctx.operanders["n_used_accesses"])
+				},
+				errCheck: errorTextContains("assertion ids.n_used_accesses == len(access_indices[key] failed"),
+			},
+		},
 	})
 }


### PR DESCRIPTION
Resolves #301 

This PR implements`SquashDictInnerUsedAccessesAssert` hint, which checks that `n_used_accesses` Cairo local variable is equal to the number of used accesses for a key during dict squashing.