### PR TITLE
feat: `SquashDictInnerContinueLoop` hint

### DIFF
--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -110,6 +110,7 @@ const (
 
 	// ------ Dictionaries hints related code ------
 	squashDictInnerAssertLenKeys string = "assert len(keys) == 0"
+	squashDictInnerContinueLoop  string = "ids.loop_temps.should_continue = 1 if current_access_indices else 0"
 	squashDictInnerLenAssert     string = "assert len(current_access_indices) == 0"
 	squashDictInnerNextKey       string = "assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()"
 

--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -161,6 +161,8 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		// Dictionaries hints
 	case squashDictInnerAssertLenKeys:
 		return createSquashDictInnerAssertLenKeysHinter()
+	case squashDictInnerContinueLoop:
+		return createSquashDictInnerContinueLoopHinter(resolver)
 	case squashDictInnerLenAssert:
 		return createSquashDictInnerLenAssertHinter()
 	case squashDictInnerNextKey:

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -55,6 +55,16 @@ func newSquashDictInnerContinueLoopHint(loopTemps hinter.ResOperander) hinter.Hi
 				return err
 			}
 
+			currentAccessIndices := currentAccessIndices_.([]f.Element)
+			if len(currentAccessIndices) != 0 {
+				return fmt.Errorf("assertion `len(current_access_indices) == 0` failed")
+			}
+
+			loopTemps, err := hinter.ResolveAsUint64(vm, loopTemps)
+			if err != nil {
+				return err
+			}
+
 			keys := keys_.([]f.Element)
 			if len(keys) == 0 {
 				return fmt.Errorf("no keys left but remaining_accesses > 0")

--- a/pkg/hintrunner/zero/zerohint_dictionaries_test.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries_test.go
@@ -37,6 +37,46 @@ func TestZeroHintDictionaries(t *testing.T) {
 				errCheck: errorTextContains("assertion `len(keys) == 0` failed"),
 			},
 		},
+		"SquashDictInnerContinueLoop": {
+			{
+				operanders: []*hintOperander{
+					{Name: "loop_temps", Kind: fpRelative, Value: addr(7)},
+					{Name: "loop_temps.index_delta_minus1", Kind: apRelative, Value: feltInt64(0)},
+					{Name: "loop_temps.index_delta", Kind: apRelative, Value: feltInt64(0)},
+					{Name: "loop_temps.ptr_delta", Kind: apRelative, Value: feltInt64(0)},
+					{Name: "loop_temps.should_continue", Kind: uninitialized},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					err := ctx.ScopeManager.AssignVariable("current_access_indices", []fp.Element{*feltUint64(1), *feltUint64(2), *feltUint64(3)})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSquashDictInnerContinueLoopHint(ctx.operanders["loop_temps"])
+				},
+				check: varValueEquals("loop_temps.should_continue", feltInt64(1)),
+			},
+			{
+				operanders: []*hintOperander{
+					{Name: "loop_temps", Kind: fpRelative, Value: addr(7)},
+					{Name: "loop_temps.index_delta_minus1", Kind: apRelative, Value: feltInt64(0)},
+					{Name: "loop_temps.index_delta", Kind: apRelative, Value: feltInt64(0)},
+					{Name: "loop_temps.ptr_delta", Kind: apRelative, Value: feltInt64(0)},
+					{Name: "loop_temps.should_continue", Kind: uninitialized},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					err := ctx.ScopeManager.AssignVariable("current_access_indices", []fp.Element{})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSquashDictInnerContinueLoopHint(ctx.operanders["loop_temps"])
+				},
+				check: varValueEquals("loop_temps.should_continue", feltInt64(0)),
+			},
+		},
 		"SquashDictInnerLenAssert": {
 			{
 				operanders: []*hintOperander{},


### PR DESCRIPTION
Resolves #299 

This PR implements `SquashDictInnerContinueLoop` hint, which checks if the squashing loop should continue or not, depending on whether there are access indices remaining or not.

It writes 1 or 0 in `should_continue` field of `loop_temps` struct variable



Here is a the `LoopTemps` struct :
```

   struct LoopTemps {
        index_delta_minus1: felt,
        index_delta: felt,
        ptr_delta: felt,
        should_continue: felt,
    }
```

I added offset of 4 to write on the 4th item of the struct, as we first store the number of items and then each item contiguously in memory