### PR TITLE
feat: `SquashDictInnerSkipLoop` hint

### DIFF
--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -112,7 +112,7 @@ const (
 	defaultDictNewCode                string = "if '__dict_manager' not in globals():\n    from starkware.cairo.common.dict import DictManager\n    __dict_manager = DictManager()\n\nmemory[ap] = __dict_manager.new_default_dict(segments, ids.default_value)"
 	squashDictInnerAssertLenKeys      string = "assert len(keys) == 0"
 	squashDictInnerContinueLoop       string = "ids.loop_temps.should_continue = 1 if current_access_indices else 0"
-  squashDictInnerSkipLoop           string = "ids.should_skip_loop = 0 if current_access_indices else 1"
+	squashDictInnerSkipLoop           string = "ids.should_skip_loop = 0 if current_access_indices else 1"
 	squashDictInnerLenAssert          string = "assert len(current_access_indices) == 0"
 	squashDictInnerNextKey            string = "assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()"
 	squashDictInnerUsedAccessesAssert string = "assert ids.n_used_accesses == len(access_indices[key])"

--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -109,6 +109,7 @@ const (
 	keccakWriteArgs string = "segments.write_arg(ids.inputs, [ids.low % 2 ** 64, ids.low // 2 ** 64])\nsegments.write_arg(ids.inputs + 2, [ids.high % 2 ** 64, ids.high // 2 ** 64])"
 
 	// ------ Dictionaries hints related code ------
+	squashDictInnerSkipLoop      string = "ids.should_skip_loop = 0 if current_access_indices else 1"
 	squashDictInnerAssertLenKeys string = "assert len(keys) == 0"
 	squashDictInnerLenAssert     string = "assert len(current_access_indices) == 0"
 	squashDictInnerNextKey       string = "assert len(keys) > 0, 'No keys left but remaining_accesses > 0.'\nids.next_key = key = keys.pop()"

--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -92,7 +92,7 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createSqrtHinter(resolver)
 	case unsignedDivRemCode:
 		return createUnsignedDivRemHinter(resolver)
-		// Uint256 hints
+	// Uint256 hints
 	case uint256AddCode:
 		return createUint256AddHinter(resolver, false)
 	case uint256AddLowCode:
@@ -120,7 +120,7 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createVerifyZeroHinter(resolver)
 	case divModNPackedDivmodV1Code:
 		return createDivModNPackedDivmodV1Hinter(resolver)
-		// EC hints
+	// EC hints
 	case ecNegateCode:
 		return createEcNegateHinter(resolver)
 	case nondetBigint3V1Code:
@@ -139,15 +139,15 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createEcDoubleAssignNewXV1Hinter(resolver)
 	case ecDoubleAssignNewYV1:
 		return createEcDoubleAssignNewYV1Hinter()
-		// Blake hints
+	// Blake hints
 	case blake2sAddUint256BigendCode:
 		return createBlake2sAddUint256Hinter(resolver, true)
 	case blake2sAddUint256Code:
 		return createBlake2sAddUint256Hinter(resolver, false)
-		// Keccak hints
+	// Keccak hints
 	case keccakWriteArgs:
 		return createKeccakWriteArgsHinter(resolver)
-		// Usort hints
+	// Usort hints
 	case usortEnterScopeCode:
 		return createUsortEnterScopeHinter()
 	case usortVerifyMultiplicityAssertCode:
@@ -158,7 +158,7 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createUsortVerifyMultiplicityBodyHinter(resolver)
 	case usortBodyCode:
 		return createUsortBodyHinter(resolver)
-		// Dictionaries hints
+	// Dictionaries hints
 	case defaultDictNewCode:
 		return createDefaultDictNewHinter(resolver)
 	case squashDictInnerAssertLenKeys:
@@ -173,7 +173,7 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createSquashDictInnerNextKeyHinter(resolver)
 	case squashDictInnerUsedAccessesAssert:
 		return createSquashDictInnerUsedAccessesAssertHinter(resolver)
-		// Other hints
+	// Other hints
 	case allocSegmentCode:
 		return createAllocSegmentHinter()
 	case vmEnterScopeCode:
@@ -185,7 +185,7 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 	case testAssignCode:
 		return createTestAssignHinter(resolver)
 	default:
-		return nil, fmt.Errorf("Not identified hint")
+		return nil, fmt.Errorf("not identified hint")
 	}
 }
 

--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -159,6 +159,8 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 	case usortBodyCode:
 		return createUsortBodyHinter(resolver)
 		// Dictionaries hints
+	case squashDictInnerSkipLoop:
+		return createSquashDictInnerSkipLoopHinter(resolver)
 	case squashDictInnerAssertLenKeys:
 		return createSquashDictInnerAssertLenKeysHinter()
 	case squashDictInnerLenAssert:

--- a/pkg/hintrunner/zero/zerohint.go
+++ b/pkg/hintrunner/zero/zerohint.go
@@ -165,7 +165,7 @@ func GetHintFromCode(program *zero.ZeroProgram, rawHint zero.Hint, hintPC uint64
 		return createSquashDictInnerAssertLenKeysHinter()
 	case squashDictInnerContinueLoop:
 		return createSquashDictInnerContinueLoopHinter(resolver)
-  case squashDictInnerSkipLoop:
+	case squashDictInnerSkipLoop:
 		return createSquashDictInnerSkipLoopHinter(resolver)
 	case squashDictInnerLenAssert:
 		return createSquashDictInnerLenAssertHinter()

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -187,6 +187,7 @@ func createSquashDictInnerSkipLoopHinter(resolver hintReferenceResolver) (hinter
 	}
 
 	return newSquashDictInnerSkipLoopHint(shouldSkipLoop), nil
+}
 
 // SquashDictInnerAssertLenKeys hint asserts the length of the current
 // access indices for a given key is zero

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -37,13 +37,12 @@ func newSquashDictInnerSkipLoopHint(shouldSkipLoop hinter.ResOperander) hinter.H
 				return err
 			}
 
-			resultMemZero := memory.MemoryValueFromFieldElement(&utils.FeltZero)
-			resultMemOne := memory.MemoryValueFromFieldElement(&utils.FeltOne)
-
 			if len(currentAccessIndices) == 0 {
+				resultMemOne := memory.MemoryValueFromFieldElement(&utils.FeltOne)
 				return vm.Memory.WriteToAddress(&shouldSkipLoopAddr, &resultMemOne)
 
 			} else {
+				resultMemZero := memory.MemoryValueFromFieldElement(&utils.FeltZero)
 				return vm.Memory.WriteToAddress(&shouldSkipLoopAddr, &resultMemZero)
 			}
 		},

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -30,7 +30,10 @@ func newSquashDictInnerSkipLoopHint(shouldSkipLoop hinter.ResOperander) hinter.H
 				return err
 			}
 
-			currentAccessIndices := currentAccessIndices_.([]fp.Element)
+			currentAccessIndices, ok := currentAccessIndices_.([]fp.Element)
+			if !ok {
+				return fmt.Errorf("casting currentAccessIndices_ into an array of felts failed")
+			}
 
 			shouldSkipLoopAddr, err := shouldSkipLoop.GetAddress(vm)
 			if err != nil {

--- a/pkg/hintrunner/zero/zerohint_dictionaries_test.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries_test.go
@@ -113,7 +113,7 @@ func TestZeroHintDictionaries(t *testing.T) {
 				check: varValueEquals("loop_temps.should_continue", feltInt64(0)),
 			},
 		},
-    "SquashDictInnerSkipLoop": {
+		"SquashDictInnerSkipLoop": {
 			{
 				operanders: []*hintOperander{
 					{Name: "should_skip_loop", Kind: uninitialized},
@@ -143,8 +143,8 @@ func TestZeroHintDictionaries(t *testing.T) {
 					return newSquashDictInnerSkipLoopHint(ctx.operanders["should_skip_loop"])
 				},
 				check: varValueEquals("should_skip_loop", feltInt64(1)),
-      },
-    },
+			},
+		},
 		"SquashDictInnerLenAssert": {
 			{
 				operanders: []*hintOperander{},

--- a/pkg/hintrunner/zero/zerohint_dictionaries_test.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries_test.go
@@ -9,6 +9,38 @@ import (
 
 func TestZeroHintDictionaries(t *testing.T) {
 	runHinterTests(t, map[string][]hintTestCase{
+		"SquashDictInnerSkipLoop": {
+			{
+				operanders: []*hintOperander{
+					{Name: "should_skip_loop", Kind: uninitialized},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					err := ctx.ScopeManager.AssignVariable("current_access_indices", []fp.Element{*feltUint64(1), *feltUint64(2), *feltUint64(3)})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSquashDictInnerSkipLoopHint(ctx.operanders["should_skip_loop"])
+				},
+				check: varValueEquals("should_skip_loop", feltInt64(0)),
+			},
+			{
+				operanders: []*hintOperander{
+					{Name: "should_skip_loop", Kind: uninitialized},
+				},
+				ctxInit: func(ctx *hinter.HintRunnerContext) {
+					err := ctx.ScopeManager.AssignVariable("current_access_indices", []fp.Element{})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
+					return newSquashDictInnerSkipLoopHint(ctx.operanders["should_skip_loop"])
+				},
+				check: varValueEquals("should_skip_loop", feltInt64(1)),
+			},
+		},
 		"SquashDictInnerAssertLenKeys": {
 			{
 				operanders: []*hintOperander{},


### PR DESCRIPTION
Resolves #297 

This PR implements `SquashDictInnerSkipLoop` hint, very similar to `SquashDictInnerContinueLoop` hint.

we don't manipulate `LoopTemps` struct here but will instead set `should_skip_loop` Cairo local variable to 0 or 1, depending on whether `current_access_indices` array still contains elements or not. 

Note i didnt respect the logic location of this hint in dict hint files, to avoid confllicts with `SquashDictInnerContinueLoop` current PR