### PR TITLE
Rectify wrongly implemented `MemcpyEnterScope` hint

### DIFF
--- a/pkg/hintrunner/zero/zerohint_others.go
+++ b/pkg/hintrunner/zero/zerohint_others.go
@@ -46,7 +46,7 @@ func newMemcpyEnterScopeHint(len hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			ctx.ScopeManager.EnterScope(map[string]any{"n": len})
+			ctx.ScopeManager.EnterScope(map[string]any{"n": *len})
 			return nil
 		},
 	}

--- a/pkg/hintrunner/zero/zerohint_others_test.go
+++ b/pkg/hintrunner/zero/zerohint_others_test.go
@@ -17,7 +17,7 @@ func TestZeroHintMemcpy(t *testing.T) {
 				makeHinter: func(ctx *hintTestContext) hinter.Hinter {
 					return newMemcpyEnterScopeHint(ctx.operanders["len"])
 				},
-				check: varValueInScopeEquals("n", feltUint64(1)),
+				check: varValueInScopeEquals("n", *feltUint64(1)),
 			},
 		},
 	})


### PR DESCRIPTION
Resolves #417 