### PR TITLE
Move WriteUint256ToAddress and WriteToNthStructField to memory package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This Virtual Machine is still in development and there is no public release avai
 Currently, it is only possible to use it by building it from source by following these instructions:
 
 1. Clone the repo to your machine: `git clone https://github.com/NethermindEth/cairo-vm-go`.
-2. Install `Go` on your PC, instructions [here](https://go.dev/.doc/install).
+2. Install `Go` on your PC, instructions [here](https://go.dev/dl/).
 3. Execute on the root folder of the repo: `make build`.
 4. Make sure everything is running smoothly by executing: `make unit`.
 

--- a/pkg/hintrunner/hinter/operand.go
+++ b/pkg/hintrunner/hinter/operand.go
@@ -6,7 +6,7 @@ import (
 	"github.com/NethermindEth/cairo-vm-go/pkg/parsers/zero"
 	"github.com/NethermindEth/cairo-vm-go/pkg/utils"
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
-	
+
 	mem "github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
 	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )

--- a/pkg/hintrunner/hinter/operand.go
+++ b/pkg/hintrunner/hinter/operand.go
@@ -6,7 +6,7 @@ import (
 	"github.com/NethermindEth/cairo-vm-go/pkg/parsers/zero"
 	"github.com/NethermindEth/cairo-vm-go/pkg/utils"
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
-	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
+	
 	mem "github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
 	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
@@ -229,22 +229,4 @@ func (v BinaryOp) ApplyApTracking(hint, ref zero.ApTracking) Reference {
 func (v Immediate) ApplyApTracking(hint, ref zero.ApTracking) Reference {
 	// Nothing to do
 	return v
-}
-
-func WriteToNthStructField(vm *VM.VirtualMachine, addr mem.MemoryAddress, value mem.MemoryValue, field int16) error {
-	nAddr, err := addr.AddOffset(field)
-	if err != nil {
-		return err
-	}
-
-	return vm.Memory.WriteToAddress(&nAddr, &value)
-}
-
-func WriteUint256ToAddress(vm *VM.VirtualMachine, addr mem.MemoryAddress, low, high *f.Element) error {
-	lowMemoryValue := memory.MemoryValueFromFieldElement(low)
-	err := vm.Memory.WriteToAddress(&addr, &lowMemoryValue)
-	if err != nil {
-		return err
-	}
-	return WriteToNthStructField(vm, addr, memory.MemoryValueFromFieldElement(high), 1)
 }

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -185,11 +185,11 @@ func newSquashDictInnerContinueLoopHint(loopTemps hinter.ResOperander) hinter.Hi
 
 			if len(currentAccessIndices) == 0 {
 				resultMemZero := memory.MemoryValueFromFieldElement(&utils.FeltZero)
-				return vm.Memory.WriteToNthStructField( loopTempsAddr, resultMemZero, int16(3))
+				return vm.Memory.WriteToNthStructField(loopTempsAddr, resultMemZero, int16(3))
 
 			} else {
 				resultMemOne := memory.MemoryValueFromFieldElement(&utils.FeltOne)
-				return vm.Memory.WriteToNthStructField( loopTempsAddr, resultMemOne, int16(3))
+				return vm.Memory.WriteToNthStructField(loopTempsAddr, resultMemOne, int16(3))
 			}
 		},
 	}

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -185,11 +185,11 @@ func newSquashDictInnerContinueLoopHint(loopTemps hinter.ResOperander) hinter.Hi
 
 			if len(currentAccessIndices) == 0 {
 				resultMemZero := memory.MemoryValueFromFieldElement(&utils.FeltZero)
-				return hinter.WriteToNthStructField(vm, loopTempsAddr, resultMemZero, int16(3))
+				return vm.Memory.WriteToNthStructField( loopTempsAddr, resultMemZero, int16(3))
 
 			} else {
 				resultMemOne := memory.MemoryValueFromFieldElement(&utils.FeltOne)
-				return hinter.WriteToNthStructField(vm, loopTempsAddr, resultMemOne, int16(3))
+				return vm.Memory.WriteToNthStructField( loopTempsAddr, resultMemOne, int16(3))
 			}
 		},
 	}

--- a/pkg/hintrunner/zero/zerohint_uint256.go
+++ b/pkg/hintrunner/zero/zerohint_uint256.go
@@ -234,7 +234,7 @@ func newUint256SqrtHint(n, root hinter.ResOperander) hinter.Hinter {
 
 			//> ids.root.low = root
 			//> ids.root.high = 0
-			return hinter.WriteUint256ToAddress(vm, rootAddr, &calculatedFeltRoot, &utils.FeltZero)
+			return vm.Memory.WriteUint256ToAddress( rootAddr, &calculatedFeltRoot, &utils.FeltZero)
 		},
 	}
 }
@@ -351,7 +351,7 @@ func newUint256UnsignedDivRemHint(a, div, quotient, remainder hinter.ResOperande
 				return err
 			}
 
-			err = hinter.WriteUint256ToAddress(vm, quotientAddr, lowQuot, highQuot)
+			err =  vm.Memory.WriteUint256ToAddress( quotientAddr, lowQuot, highQuot)
 			if err != nil {
 				return err
 			}
@@ -361,7 +361,7 @@ func newUint256UnsignedDivRemHint(a, div, quotient, remainder hinter.ResOperande
 				return err
 			}
 
-			return hinter.WriteUint256ToAddress(vm, remainderAddr, lowRem, highRem)
+			return  vm.Memory.WriteUint256ToAddress( remainderAddr, lowRem, highRem)
 		},
 	}
 }
@@ -458,7 +458,7 @@ func newUint256MulDivModHint(a, b, div, quotientLow, quotientHigh, remainder hin
 				return err
 			}
 
-			err = hinter.WriteUint256ToAddress(vm, quotientLowAddr, lowQuotLow, lowQuotHigh)
+			err =  vm.Memory.WriteUint256ToAddress( quotientLowAddr, lowQuotLow, lowQuotHigh)
 			if err != nil {
 				return err
 			}
@@ -468,7 +468,7 @@ func newUint256MulDivModHint(a, b, div, quotientLow, quotientHigh, remainder hin
 				return err
 			}
 
-			err = hinter.WriteUint256ToAddress(vm, quotientHighAddr, highQuotLow, highQuotHigh)
+			err =  vm.Memory.WriteUint256ToAddress( quotientHighAddr, highQuotLow, highQuotHigh)
 			if err != nil {
 				return err
 			}
@@ -478,7 +478,7 @@ func newUint256MulDivModHint(a, b, div, quotientLow, quotientHigh, remainder hin
 				return err
 			}
 
-			return hinter.WriteUint256ToAddress(vm, remainderAddr, lowRem, highRem)
+			return  vm.Memory.WriteUint256ToAddress( remainderAddr, lowRem, highRem)
 		},
 	}
 }

--- a/pkg/hintrunner/zero/zerohint_uint256.go
+++ b/pkg/hintrunner/zero/zerohint_uint256.go
@@ -234,7 +234,7 @@ func newUint256SqrtHint(n, root hinter.ResOperander) hinter.Hinter {
 
 			//> ids.root.low = root
 			//> ids.root.high = 0
-			return vm.Memory.WriteUint256ToAddress( rootAddr, &calculatedFeltRoot, &utils.FeltZero)
+			return vm.Memory.WriteUint256ToAddress(rootAddr, &calculatedFeltRoot, &utils.FeltZero)
 		},
 	}
 }
@@ -351,7 +351,7 @@ func newUint256UnsignedDivRemHint(a, div, quotient, remainder hinter.ResOperande
 				return err
 			}
 
-			err =  vm.Memory.WriteUint256ToAddress( quotientAddr, lowQuot, highQuot)
+			err = vm.Memory.WriteUint256ToAddress(quotientAddr, lowQuot, highQuot)
 			if err != nil {
 				return err
 			}
@@ -361,7 +361,7 @@ func newUint256UnsignedDivRemHint(a, div, quotient, remainder hinter.ResOperande
 				return err
 			}
 
-			return  vm.Memory.WriteUint256ToAddress( remainderAddr, lowRem, highRem)
+			return vm.Memory.WriteUint256ToAddress(remainderAddr, lowRem, highRem)
 		},
 	}
 }
@@ -458,7 +458,7 @@ func newUint256MulDivModHint(a, b, div, quotientLow, quotientHigh, remainder hin
 				return err
 			}
 
-			err =  vm.Memory.WriteUint256ToAddress( quotientLowAddr, lowQuotLow, lowQuotHigh)
+			err = vm.Memory.WriteUint256ToAddress(quotientLowAddr, lowQuotLow, lowQuotHigh)
 			if err != nil {
 				return err
 			}
@@ -468,7 +468,7 @@ func newUint256MulDivModHint(a, b, div, quotientLow, quotientHigh, remainder hin
 				return err
 			}
 
-			err =  vm.Memory.WriteUint256ToAddress( quotientHighAddr, highQuotLow, highQuotHigh)
+			err = vm.Memory.WriteUint256ToAddress(quotientHighAddr, highQuotLow, highQuotHigh)
 			if err != nil {
 				return err
 			}
@@ -478,7 +478,7 @@ func newUint256MulDivModHint(a, b, div, quotientLow, quotientHigh, remainder hin
 				return err
 			}
 
-			return  vm.Memory.WriteUint256ToAddress( remainderAddr, lowRem, highRem)
+			return vm.Memory.WriteUint256ToAddress(remainderAddr, lowRem, highRem)
 		},
 	}
 }

--- a/pkg/vm/memory/memory.go
+++ b/pkg/vm/memory/memory.go
@@ -358,3 +358,20 @@ func (memory *Memory) FindSegmentWithBuiltin(builtinName string) (*Segment, bool
 	}
 	return nil, false
 }
+
+func (memory *Memory) WriteUint256ToAddress( addr MemoryAddress, low, high *f.Element) error {
+	lowMemoryValue := MemoryValueFromFieldElement(low)
+	err := memory.WriteToAddress(&addr, &lowMemoryValue)
+	if err != nil {
+		return err
+	}
+	return memory.WriteToNthStructField( addr, MemoryValueFromFieldElement(high), 1)
+}
+
+func (memory *Memory) WriteToNthStructField( addr MemoryAddress, value MemoryValue, field int16) error {
+	nAddr, err := addr.AddOffset(field)
+	if err != nil {
+		return err
+	}
+	return memory.WriteToAddress(&nAddr, &value)
+}

--- a/pkg/vm/memory/memory.go
+++ b/pkg/vm/memory/memory.go
@@ -359,16 +359,16 @@ func (memory *Memory) FindSegmentWithBuiltin(builtinName string) (*Segment, bool
 	return nil, false
 }
 
-func (memory *Memory) WriteUint256ToAddress( addr MemoryAddress, low, high *f.Element) error {
+func (memory *Memory) WriteUint256ToAddress(addr MemoryAddress, low, high *f.Element) error {
 	lowMemoryValue := MemoryValueFromFieldElement(low)
 	err := memory.WriteToAddress(&addr, &lowMemoryValue)
 	if err != nil {
 		return err
 	}
-	return memory.WriteToNthStructField( addr, MemoryValueFromFieldElement(high), 1)
+	return memory.WriteToNthStructField(addr, MemoryValueFromFieldElement(high), 1)
 }
 
-func (memory *Memory) WriteToNthStructField( addr MemoryAddress, value MemoryValue, field int16) error {
+func (memory *Memory) WriteToNthStructField(addr MemoryAddress, value MemoryValue, field int16) error {
 	nAddr, err := addr.AddOffset(field)
 	if err != nil {
 		return err


### PR DESCRIPTION
- Move WriteUint256ToAddress from hinter package to memory package
-  Move WriteToNthStructField from hinter package to memory package
- IMPORTANT NOTE:  I know that i dont have to move WriteToNthStructField but if i want to migrate the WriteUint256ToAddress  i have to move WriteToNthStructField too, because inside in the WriteUint256ToAddress i have to call WriteToNthStructField ).
- Fix the calls in the source code  for the two functions (WriteUint256ToAddress, WriteToNthStructField )

Project build sucess:
![image](https://github.com/NethermindEth/cairo-vm-go/assets/54730752/ef2d0764-1448-4c27-ba63-ed000e5daf6f)
Test run sucess:
![image](https://github.com/NethermindEth/cairo-vm-go/assets/54730752/76333456-7cbc-40d5-8ddc-f59e63870294)


