### PR TITLE
chore: move `WriteToNthStructField()` to `memory.go`

### DIFF
--- a/pkg/hintrunner/hinter/operand.go
+++ b/pkg/hintrunner/hinter/operand.go
@@ -230,21 +230,3 @@ func (v Immediate) ApplyApTracking(hint, ref zero.ApTracking) Reference {
 	// Nothing to do
 	return v
 }
-
-func WriteToNthStructField(vm *VM.VirtualMachine, addr mem.MemoryAddress, value mem.MemoryValue, field int16) error {
-	nAddr, err := addr.AddOffset(field)
-	if err != nil {
-		return err
-	}
-
-	return vm.Memory.WriteToAddress(&nAddr, &value)
-}
-
-func WriteUint256ToAddress(vm *VM.VirtualMachine, addr mem.MemoryAddress, low, high *f.Element) error {
-	lowMemoryValue := memory.MemoryValueFromFieldElement(low)
-	err := vm.Memory.WriteToAddress(&addr, &lowMemoryValue)
-	if err != nil {
-		return err
-	}
-	return WriteToNthStructField(vm, addr, memory.MemoryValueFromFieldElement(high), 1)
-}

--- a/pkg/hintrunner/hinter/operand.go
+++ b/pkg/hintrunner/hinter/operand.go
@@ -6,7 +6,6 @@ import (
 	"github.com/NethermindEth/cairo-vm-go/pkg/parsers/zero"
 	"github.com/NethermindEth/cairo-vm-go/pkg/utils"
 	VM "github.com/NethermindEth/cairo-vm-go/pkg/vm"
-	"github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
 	mem "github.com/NethermindEth/cairo-vm-go/pkg/vm/memory"
 	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )

--- a/pkg/hintrunner/zero/zerohint_dictionaries.go
+++ b/pkg/hintrunner/zero/zerohint_dictionaries.go
@@ -185,11 +185,11 @@ func newSquashDictInnerContinueLoopHint(loopTemps hinter.ResOperander) hinter.Hi
 
 			if len(currentAccessIndices) == 0 {
 				resultMemZero := memory.MemoryValueFromFieldElement(&utils.FeltZero)
-				return hinter.WriteToNthStructField(vm, loopTempsAddr, resultMemZero, int16(3))
+				return vm.Memory.WriteToNthStructField(loopTempsAddr, resultMemZero, int16(3))
 
 			} else {
 				resultMemOne := memory.MemoryValueFromFieldElement(&utils.FeltOne)
-				return hinter.WriteToNthStructField(vm, loopTempsAddr, resultMemOne, int16(3))
+				return vm.Memory.WriteToNthStructField(vm, loopTempsAddr, resultMemOne, int16(3))
 			}
 		},
 	}

--- a/pkg/hintrunner/zero/zerohint_uint256.go
+++ b/pkg/hintrunner/zero/zerohint_uint256.go
@@ -234,7 +234,7 @@ func newUint256SqrtHint(n, root hinter.ResOperander) hinter.Hinter {
 
 			//> ids.root.low = root
 			//> ids.root.high = 0
-			return hinter.WriteUint256ToAddress(vm, rootAddr, &calculatedFeltRoot, &utils.FeltZero)
+			return vm.Memory.WriteUint256ToAddress(rootAddr, &calculatedFeltRoot, &utils.FeltZero)
 		},
 	}
 }
@@ -351,7 +351,7 @@ func newUint256UnsignedDivRemHint(a, div, quotient, remainder hinter.ResOperande
 				return err
 			}
 
-			err = hinter.WriteUint256ToAddress(vm, quotientAddr, lowQuot, highQuot)
+			err = vm.Memory.WriteUint256ToAddress(quotientAddr, lowQuot, highQuot)
 			if err != nil {
 				return err
 			}
@@ -361,7 +361,7 @@ func newUint256UnsignedDivRemHint(a, div, quotient, remainder hinter.ResOperande
 				return err
 			}
 
-			return hinter.WriteUint256ToAddress(vm, remainderAddr, lowRem, highRem)
+			return vm.Memory.WriteUint256ToAddress(remainderAddr, lowRem, highRem)
 		},
 	}
 }
@@ -458,7 +458,7 @@ func newUint256MulDivModHint(a, b, div, quotientLow, quotientHigh, remainder hin
 				return err
 			}
 
-			err = hinter.WriteUint256ToAddress(vm, quotientLowAddr, lowQuotLow, lowQuotHigh)
+			err = vm.Memory.WriteUint256ToAddress(quotientLowAddr, lowQuotLow, lowQuotHigh)
 			if err != nil {
 				return err
 			}
@@ -468,7 +468,7 @@ func newUint256MulDivModHint(a, b, div, quotientLow, quotientHigh, remainder hin
 				return err
 			}
 
-			err = hinter.WriteUint256ToAddress(vm, quotientHighAddr, highQuotLow, highQuotHigh)
+			err = vm.Memory.WriteUint256ToAddress(quotientHighAddr, highQuotLow, highQuotHigh)
 			if err != nil {
 				return err
 			}
@@ -478,7 +478,7 @@ func newUint256MulDivModHint(a, b, div, quotientLow, quotientHigh, remainder hin
 				return err
 			}
 
-			return hinter.WriteUint256ToAddress(vm, remainderAddr, lowRem, highRem)
+			return vm.Memory.WriteUint256ToAddress(remainderAddr, lowRem, highRem)
 		},
 	}
 }

--- a/pkg/vm/memory/memory.go
+++ b/pkg/vm/memory/memory.go
@@ -358,3 +358,21 @@ func (memory *Memory) FindSegmentWithBuiltin(builtinName string) (*Segment, bool
 	}
 	return nil, false
 }
+
+func WriteToNthStructField(vm *VM.VirtualMachine, addr mem.MemoryAddress, value mem.MemoryValue, field int16) error {
+	nAddr, err := addr.AddOffset(field)
+	if err != nil {
+		return err
+	}
+
+	return vm.Memory.WriteToAddress(&nAddr, &value)
+}
+
+func WriteUint256ToAddress(vm *VM.VirtualMachine, addr mem.MemoryAddress, low, high *f.Element) error {
+	lowMemoryValue := memory.MemoryValueFromFieldElement(low)
+	err := vm.Memory.WriteToAddress(&addr, &lowMemoryValue)
+	if err != nil {
+		return err
+	}
+	return WriteToNthStructField(vm, addr, memory.MemoryValueFromFieldElement(high), 1)
+}


### PR DESCRIPTION
### Related issue
- Closes #426 

### Description
- Moved `WriteToNthStructField()` from `hintrunner/hinter/operand.go` to `vm/memory/memory.go`
- Also moved the `WriteUint256ToAddress()` as well because it utilises `WriteToNthStructField()` internally.
- Lastly, update usage of both `WriteToNthStructField()` and `WriteUint256ToAddress()` across the codebase.
