### PR TITLE
Fixed a scope bug, updated comments and fixed hint code strings

### DIFF
--- a/pkg/hintrunner/zero/hintcode.go
+++ b/pkg/hintrunner/zero/hintcode.go
@@ -91,7 +91,7 @@ const (
 	fastEcAddAssignNewXCode string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nslope = pack(ids.slope, PRIME)\nx0 = pack(ids.point0.x, PRIME)\nx1 = pack(ids.point1.x, PRIME)\ny0 = pack(ids.point0.y, PRIME)\n\nvalue = new_x = (pow(slope, 2, SECP_P) - x0 - x1) % SECP_P"
 	fastEcAddAssignNewYCode string = "value = new_y = (slope * (x0 - new_x) - y0) % SECP_P"
 	ecDoubleSlopeV1Code     string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nfrom starkware.python.math_utils import ec_double_slope\n\n# Compute the slope.\nx = pack(ids.point.x, PRIME)\ny = pack(ids.point.y, PRIME)\nvalue = slope = ec_double_slope(point=(x, y), alpha=0, p=SECP_P)"
-	reduceV1Code            string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack	value = pack(ids.x, PRIME) % SECP_P"
+	reduceV1Code            string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P"
 	computeSlopeV1Code      string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nfrom starkware.python.math_utils import line_slope\n\n# Compute the slope.\nx0 = pack(ids.point0.x, PRIME)\ny0 = pack(ids.point0.y, PRIME)\nx1 = pack(ids.point1.x, PRIME)\ny1 = pack(ids.point1.y, PRIME)\nvalue = slope = line_slope(point1=(x0, y0), point2=(x1, y1), p=SECP_P)"
 	ecDoubleAssignNewXV1    string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nslope = pack(ids.slope, PRIME)\nx = pack(ids.point.x, PRIME)\ny = pack(ids.point.y, PRIME)\n\nvalue = new_x = (pow(slope, 2, SECP_P) - 2 * x) % SECP_P"
 	ecDoubleAssignNewYV1    string = "value = new_y = (slope * (x - new_x) - y) % SECP_P"
@@ -100,7 +100,7 @@ const (
 
 	// ------ Signature hints related code ------
 	verifyECDSASignatureCode  string = "ecdsa_builtin.add_signature(ids.ecdsa_ptr.address_, (ids.signature_r, ids.signature_s))"
-	getPointFromXCode         string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nx_cube_int = pack(ids.x_cube, PRIME) % SECP_P\ny_square_int = (x_cube_int + ids.BETA) % SECP_P\ny = pow(y_square_int, (SECP_P + 1) // 4, SECP_P)\nif ids.v % 2 == y % 2:\nvalue = y\nelse:\nvalue = (-y) % SECP_P"
+	getPointFromXCode         string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nx_cube_int = pack(ids.x_cube, PRIME) % SECP_P\ny_square_int = (x_cube_int + ids.BETA) % SECP_P\ny = pow(y_square_int, (SECP_P + 1) // 4, SECP_P)\n\n# We need to decide whether to take y or SECP_P - y.\nif ids.v % 2 == y % 2:\n    value = y\nelse:\n    value = (-y) % SECP_P"
 	divModNSafeDivCode        string = "value = k = safe_div(res * b - a, N)"
 	importSecp256R1PCode      string = "from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P as SECP_P"
 	verifyZeroCode            string = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME"

--- a/pkg/hintrunner/zero/zerohint_signature.go
+++ b/pkg/hintrunner/zero/zerohint_signature.go
@@ -12,16 +12,16 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
-// VerifyZero hint verifies that a packed value is zero modulo the SECP256R1 prime
+// VerifyZero hint verifies that a packed value is zero modulo the SECP prime
 // and stores in memory the quotient of the modular divison of the packed value by
-// SECP256R1 prime
+// SECP prime
 //
 // `newVerifyZeroHint` takes 2 operanders as arguments
 //   - `value` is the value that will be verified
 //   - `q` is the variable that will store the quotient of the modular division
 //
 // `newVerifyZeroHint` writes the quotient of the modular division of the packed value
-// by SECP256R1 prime to the memory address corresponding to `q`
+// by SECP prime to the memory address corresponding to `q`
 func newVerifyZeroHint(val, q hinter.ResOperander) hinter.Hinter {
 	return &GenericZeroHinter{
 		Name: "VerifyZero",
@@ -30,8 +30,6 @@ func newVerifyZeroHint(val, q hinter.ResOperander) hinter.Hinter {
 			//> q, r = divmod(pack(ids.val, PRIME), SECP_P)
 			//> assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
 			//> ids.q = q % PRIME
-
-			//> from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
 
 			valAddr, err := val.GetAddress(vm)
 			if err != nil {
@@ -165,9 +163,9 @@ func newGetPointFromXHint(xCube, v hinter.ResOperander) hinter.Hinter {
 			//> y_square_int = (x_cube_int + ids.BETA) % SECP_P
 			//> y = pow(y_square_int, (SECP_P + 1) // 4, SECP_P)
 			//> if ids.v % 2 == y % 2:
-			//>	 value = y
+			//>		value = y
 			//> else:
-			//>	 value = (-y) % SECP_P
+			//>		value = (-y) % SECP_P
 
 			xCubeAddr, err := xCube.GetAddress(vm)
 			if err != nil {
@@ -297,7 +295,9 @@ func newDivModSafeDivHint() hinter.Hinter {
 				return err
 			}
 
-			return ctx.ScopeManager.AssignVariable("value", &value)
+			value_Big := new(big.Int).Set(&value)
+
+			return ctx.ScopeManager.AssignVariable("value", value_Big)
 		},
 	}
 }
@@ -319,6 +319,7 @@ func newDivModNPackedDivmodV1Hint(a, b hinter.ResOperander) hinter.Hinter {
 		Op: func(vm *VM.VirtualMachine, ctx *hinter.HintRunnerContext) error {
 			//> from starkware.cairo.common.cairo_secp.secp_utils import N, pack
 			//> from starkware.python.math_utils import div_mod, safe_div
+			//>
 			//> a = pack(ids.a, PRIME)
 			//> b = pack(ids.b, PRIME)
 			//> value = res = div_mod(a, b, N)
@@ -366,9 +367,33 @@ func newDivModNPackedDivmodV1Hint(a, b hinter.ResOperander) hinter.Hinter {
 				return err
 			}
 
-			valueBig := new(big.Int).Set(&resBig)
+			value_Big := new(big.Int).Set(&resBig)
+			res_Big := new(big.Int).Set(&resBig)
+			a_Big := new(big.Int).Set(&aPackedBig)
+			b_Big := new(big.Int).Set(&bPackedBig)
+			n_Big := new(big.Int).Set(&nBig)
 
-			return ctx.ScopeManager.AssignVariable("value", valueBig)
+			if err := ctx.ScopeManager.AssignVariable("res", res_Big); err != nil {
+				return err
+			}
+
+			if err := ctx.ScopeManager.AssignVariable("a", a_Big); err != nil {
+				return err
+			}
+
+			if err := ctx.ScopeManager.AssignVariable("b", b_Big); err != nil {
+				return err
+			}
+
+			if err := ctx.ScopeManager.AssignVariable("N", n_Big); err != nil {
+				return err
+			}
+
+			if err := ctx.ScopeManager.AssignVariable("value", value_Big); err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
A couple changes in this one : 

1. `DivModNPackedDivmodV1` hint didn't add a , b and N variables in scope, while these are used in the next hint `div_mod_n` int `recover_public_key` cairo function
2. in the hint `newVerifyZeroHint` in the comments we have written `SECP256R1` but its `SECP`
3. in the hint `newGetPointFromXHint` the hint code was not properly formatted so rectified it, both in the comments and in the `hintcode.go` file
4. the string for `reduceV1Code` is also not properly formatted, it does not take into account the extra space after line end