### PR TITLE
feat: implement `starknet` layout

### DIFF
--- a/integration_tests/cairozero_test.go
+++ b/integration_tests/cairozero_test.go
@@ -288,12 +288,12 @@ func runPythonVm(testFilename, path string) (time.Duration, string, string, erro
 	// A file without this suffix will use the default ("plain") layout.
 	if strings.HasSuffix(testFilename, ".small.cairo") {
 		args = append(args, "--layout", "small")
-	} else if strings.HasSuffix(testFilename, ".starknet_without_keccak.cairo") {
-		args = append(args, "--layout", "starknet")
 	} else if strings.HasSuffix(testFilename, ".dex.cairo") {
 		args = append(args, "--layout", "dex")
 	} else if strings.HasSuffix(testFilename, ".starknet_with_keccak.cairo") {
 		args = append(args, "--layout", "starknet_with_keccak")
+	} else if strings.HasSuffix(testFilename, ".starknet.cairo") {
+		args = append(args, "--layout", "starknet")
 	} else if strings.HasSuffix(testFilename, ".recursive_large_output.cairo") {
 		args = append(args, "--layout", "recursive_large_output")
 	} else if strings.HasSuffix(testFilename, ".recursive_with_poseidon.cairo") {

--- a/integration_tests/cairozero_test.go
+++ b/integration_tests/cairozero_test.go
@@ -288,6 +288,8 @@ func runPythonVm(testFilename, path string) (time.Duration, string, string, erro
 	// A file without this suffix will use the default ("plain") layout.
 	if strings.HasSuffix(testFilename, ".small.cairo") {
 		args = append(args, "--layout", "small")
+	} else if strings.HasSuffix(testFilename, ".starknet_without_keccak.cairo") {
+		args = append(args, "--layout", "starknet")
 	} else if strings.HasSuffix(testFilename, ".starknet_with_keccak.cairo") {
 		args = append(args, "--layout", "starknet_with_keccak")
 	}
@@ -321,6 +323,8 @@ func runVm(path string) (time.Duration, string, string, string, error) {
 	layout := "plain"
 	if strings.Contains(path, ".small") {
 		layout = "small"
+	} else if strings.Contains(path, ".starknet_without_keccak") {
+		layout = "starknet"
 	} else if strings.Contains(path, ".starknet_with_keccak") {
 		layout = "starknet_with_keccak"
 	}

--- a/integration_tests/cairozero_test.go
+++ b/integration_tests/cairozero_test.go
@@ -329,12 +329,12 @@ func runVm(path string) (time.Duration, string, string, string, error) {
 	layout := "plain"
 	if strings.Contains(path, ".small") {
 		layout = "small"
-	} else if strings.Contains(path, ".starknet_without_keccak") {
-		layout = "starknet"
 	} else if strings.Contains(path, ".dex") {
 		layout = "dex"
 	} else if strings.Contains(path, ".starknet_with_keccak") {
 		layout = "starknet_with_keccak"
+	} else if strings.Contains(path, ".starknet") {
+		layout = "starknet"
 	} else if strings.Contains(path, ".recursive_large_output") {
 		layout = "recursive_large_output"
 	} else if strings.Contains(path, ".recursive_with_poseidon") {

--- a/pkg/vm/builtins/layouts.go
+++ b/pkg/vm/builtins/layouts.go
@@ -37,6 +37,19 @@ func getPlainLayout() Layout {
 	return Layout{Name: "plain", RcUnits: 16, Builtins: []LayoutBuiltin{}}
 }
 
+func getStarknetLayout() Layout {
+	return Layout{Name: "starknet", RcUnits: 4, Builtins: []LayoutBuiltin{
+		{Runner: &Output{}, Builtin: starknet.Output},
+		{Runner: &Pedersen{ratio: 32}, Builtin: starknet.Pedersen},
+		{Runner: &RangeCheck{ratio: 16, RangeCheckNParts: 8}, Builtin: starknet.RangeCheck},
+		{Runner: &ECDSA{ratio: 2048}, Builtin: starknet.ECDSA},
+		{Runner: &Bitwise{ratio: 64}, Builtin: starknet.Bitwise},
+		{Runner: &EcOp{ratio: 1024, cache: make(map[uint64]fp.Element)}, Builtin: starknet.ECOP},
+		{Runner: &Keccak{ratio: 2048, cache: make(map[uint64]fp.Element)}, Builtin: starknet.Keccak},
+		{Runner: &Poseidon{ratio: 32, cache: make(map[uint64]fp.Element)}, Builtin: starknet.Poseidon},
+	}}
+}
+
 func getStarknetWithKeccakLayout() Layout {
 	return Layout{Name: "starknet_with_keccak", RcUnits: 4, Builtins: []LayoutBuiltin{
 		{Runner: &Output{}, Builtin: starknet.Output},
@@ -56,6 +69,8 @@ func GetLayout(layout string) (Layout, error) {
 		return getSmallLayout(), nil
 	case "plain":
 		return getPlainLayout(), nil
+	case "starknet":
+		return getStarknetLayout(), nil
 	case "starknet_with_keccak":
 		return getStarknetWithKeccakLayout(), nil
 	case "":

--- a/pkg/vm/builtins/layouts.go
+++ b/pkg/vm/builtins/layouts.go
@@ -95,12 +95,12 @@ func GetLayout(layout string) (Layout, error) {
 	switch layout {
 	case "plain":
 		return getPlainLayout(), nil
-	case "starknet":
-		return getStarknetLayout(), nil
 	case "small":
 		return getSmallLayout(), nil
 	case "dex":
 		return getDexLayout(), nil
+	case "starknet":
+		return getStarknetLayout(), nil
 	case "starknet_with_keccak":
 		return getStarknetWithKeccakLayout(), nil
 	case "recursive_large_output":

--- a/pkg/vm/builtins/layouts.go
+++ b/pkg/vm/builtins/layouts.go
@@ -45,7 +45,6 @@ func getStarknetLayout() Layout {
 		{Runner: &ECDSA{ratio: 2048}, Builtin: starknet.ECDSA},
 		{Runner: &Bitwise{ratio: 64}, Builtin: starknet.Bitwise},
 		{Runner: &EcOp{ratio: 1024, cache: make(map[uint64]fp.Element)}, Builtin: starknet.ECOP},
-		{Runner: &Keccak{ratio: 2048, cache: make(map[uint64]fp.Element)}, Builtin: starknet.Keccak},
 		{Runner: &Poseidon{ratio: 32, cache: make(map[uint64]fp.Element)}, Builtin: starknet.Poseidon},
 	}}
 }


### PR DESCRIPTION
This PR implements the `starknet` layout, which is identical to starknet_with_keccak except there is no keccak builtin in it

Note that i used the suffix `starknet_without_keccak` , otherwise `strings.Contains()` would induce a conflict with `starknet_with_keccak` if we call it only `starknet` 