### PR TITLE
feat: implement `recursive_large_output` layout

### DIFF
--- a/integration_tests/cairozero_test.go
+++ b/integration_tests/cairozero_test.go
@@ -290,6 +290,8 @@ func runPythonVm(testFilename, path string) (time.Duration, string, string, erro
 		args = append(args, "--layout", "small")
 	} else if strings.HasSuffix(testFilename, ".starknet_with_keccak.cairo") {
 		args = append(args, "--layout", "starknet_with_keccak")
+	} else if strings.HasSuffix(testFilename, ".recursive_large_output.cairo") {
+		args = append(args, "--layout", "recursive_large_output")
 	}
 
 	cmd := exec.Command("cairo-run", args...)
@@ -323,6 +325,8 @@ func runVm(path string) (time.Duration, string, string, string, error) {
 		layout = "small"
 	} else if strings.Contains(path, ".starknet_with_keccak") {
 		layout = "starknet_with_keccak"
+	} else if strings.Contains(path, ".recursive_large_output") {
+		layout = "recursive_large_output"
 	}
 
 	cmd := exec.Command(

--- a/pkg/vm/builtins/layouts.go
+++ b/pkg/vm/builtins/layouts.go
@@ -50,6 +50,16 @@ func getStarknetWithKeccakLayout() Layout {
 	}}
 }
 
+func getRecursiveLargeOutputLayout() Layout {
+	return Layout{Name: "recursive_large_output", RcUnits: 4, Builtins: []LayoutBuiltin{
+		{Runner: &Output{}, Builtin: starknet.Output},
+		{Runner: &Pedersen{ratio: 128}, Builtin: starknet.Pedersen},
+		{Runner: &RangeCheck{ratio: 8, RangeCheckNParts: 8}, Builtin: starknet.RangeCheck},
+		{Runner: &Bitwise{ratio: 8}, Builtin: starknet.Bitwise},
+		{Runner: &Poseidon{ratio: 8, cache: make(map[uint64]fp.Element)}, Builtin: starknet.Poseidon},
+	}}
+}
+
 func GetLayout(layout string) (Layout, error) {
 	switch layout {
 	case "small":
@@ -58,6 +68,8 @@ func GetLayout(layout string) (Layout, error) {
 		return getPlainLayout(), nil
 	case "starknet_with_keccak":
 		return getStarknetWithKeccakLayout(), nil
+	case "recursive_large_output":
+		return getRecursiveLargeOutputLayout(), nil
 	case "":
 		return getPlainLayout(), nil
 	default:


### PR DESCRIPTION
This PR implements the `recursive_large_output` layout, which contains : 
- output
- pedersen with 128 ratio
- rangecheck default (ie 8 ratio)
- bitwise with 8 ratio
- poseidon with 8 ratio