### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/hintrunner/zero/zerohint_keccak.go
+++ b/pkg/hintrunner/zero/zerohint_keccak.go
@@ -39,7 +39,7 @@ func newCairoKeccakFinalizeHint(keccakPtrEnd hinter.Reference) hinter.Hinter {
 
 			var input [25]uint64
 			builtins.KeccakF1600(&input)
-			padding := make([]uint64, keccakStateSizeFeltsVal)
+			padding := make([]uint64, 0, keccakStateSizeFeltsVal)
 			padding = append(padding, input[:]...)
 			result := make([]uint64, 0, keccakStateSizeFeltsVal*blockSizeVal)
 			for i := uint64(0); i < blockSizeVal; i++ {


### PR DESCRIPTION
The purpose here should be to initialize a slice with a capacity of keccakStateSizeFeltsVal  and a length of 0, and then append it later. Instead of initializing the length to keccakStateSizeFeltsVal  from the beginning, the resulting slice will not meet expectations.

The online demo: https://go.dev/play/p/q1BcVCmvidW