### PR TITLE
fix(vm): remove go:nosplit from RunInstruction func

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -169,7 +169,6 @@ func (vm *VirtualMachine) RunStep(hintRunner HintRunner) error {
 
 const RC_OFFSET_BITS = 16
 
-//go:nosplit
 func (vm *VirtualMachine) RunInstruction(instruction *asmb.Instruction) error {
 
 	var off0 int = int(instruction.OffDest) + (1 << (RC_OFFSET_BITS - 1))


### PR DESCRIPTION
When debugging (with go-delve) some optimizations are skipped which mean this function exceeds the maximum Go stack frame. When this happens, Go usually splits the function but since there was an explicit "nosplit" the code is unable to compile and makes impossible to debug any functionality that uses `RunInstruction`.