### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -306,13 +306,13 @@ func (runner *Runner) initializeBuiltins(memory *mem.Memory) ([]mem.MemoryValue,
 
 	for _, bRunner := range runner.layout.Builtins {
 		if runner.isCairoMode() {
-			if utils.Contains(runner.program.Builtins, bRunner.Builtin) {
+			if slices.Contains(runner.program.Builtins, bRunner.Builtin) {
 				builtinSegment := memory.AllocateBuiltinSegment(bRunner.Runner)
 				stack = append(stack, mem.MemoryValueFromMemoryAddress(&builtinSegment))
 			}
 		} else {
 			builtinSegment := memory.AllocateBuiltinSegment(bRunner.Runner)
-			if utils.Contains(runner.program.Builtins, bRunner.Builtin) {
+			if slices.Contains(runner.program.Builtins, bRunner.Builtin) {
 				stack = append(stack, mem.MemoryValueFromMemoryAddress(&builtinSegment))
 			}
 		}

--- a/pkg/utils/arrays.go
+++ b/pkg/utils/arrays.go
@@ -20,12 +20,3 @@ func Pop[T any](a *[]T) (T, error) {
 	*a = (*a)[:len(*a)-1]
 	return v, nil
 }
-
-func Contains[T comparable](a []T, v T) bool {
-	for _, e := range a {
-		if e == v {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.