### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/hintrunner/zero/zerohint_ec.go
+++ b/pkg/hintrunner/zero/zerohint_ec.go
@@ -55,7 +55,7 @@ func newGetHighLenHint(len_hi, scalar_u, scalar_v hinter.Reference) hinter.Hinte
 			bitLenU := scalarUD2.BitLen()
 			bitLenV := scalarVD2.BitLen()
 
-			lenHi := utils.Max(bitLenU, bitLenV) - 1
+			lenHi := max(bitLenU, bitLenV) - 1
 
 			lenHiAddr, err := len_hi.Get(vm)
 			if err != nil {

--- a/pkg/hintrunner/zero/zerohint_keccak.go
+++ b/pkg/hintrunner/zero/zerohint_keccak.go
@@ -138,7 +138,7 @@ func newUnsafeKeccakHint(data, length, high, low hinter.Reference) hinter.Hinter
 				word := uint256.Int(wordFelt.Bits())
 
 				//>		n_bytes = min(16, length - byte_i)
-				nBytes := utils.Min(lengthVal-i, 16)
+				nBytes := min(lengthVal-i, 16)
 
 				//>		assert 0 <= word < 2 ** (8 * n_bytes)
 				if uint64(word.BitLen()) >= 8*nBytes {

--- a/pkg/utils/math.go
+++ b/pkg/utils/math.go
@@ -7,8 +7,6 @@ import (
 	"math/big"
 	"math/bits"
 
-	"golang.org/x/exp/constraints"
-
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
@@ -57,20 +55,6 @@ func NextPowerOfTwo(n uint64) uint64 {
 
 	higherBit := 64 - bits.LeadingZeros64(n)
 	return 1 << higherBit
-}
-
-func Max[T constraints.Integer](a, b T) T {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func Min[T constraints.Integer](a, b T) T {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 // FeltLt implements `a < b` felt comparison.

--- a/pkg/vm/memory/memory.go
+++ b/pkg/vm/memory/memory.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/NethermindEth/cairo-vm-go/pkg/utils"
 	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
@@ -158,7 +157,7 @@ func (segment *Segment) IncreaseSegmentSize(newSize uint64) {
 	if cap(segmentData) > int(newSize) {
 		newSegmentData = segmentData[:cap(segmentData)]
 	} else {
-		newSegmentData = make([]MemoryValue, utils.Max(newSize, uint64(len(segmentData)*2)))
+		newSegmentData = make([]MemoryValue, max(newSize, uint64(len(segmentData)*2)))
 		copy(newSegmentData, segmentData)
 	}
 	segment.Data = newSegmentData

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -179,10 +179,10 @@ func (vm *VirtualMachine) RunInstruction(instruction *asmb.Instruction) error {
 	var off1 int = int(instruction.OffOp0) + (1 << (RC_OFFSET_BITS - 1))
 	var off2 int = int(instruction.OffOp1) + (1 << (RC_OFFSET_BITS - 1))
 
-	value := uint16(utils.Max(off0, utils.Max(off1, off2)))
-	vm.RcLimitsMax = utils.Max(vm.RcLimitsMax, value)
-	value = uint16(utils.Min(off0, utils.Min(off1, off2)))
-	vm.RcLimitsMin = utils.Min(vm.RcLimitsMin, value)
+	value := uint16(max(off0, max(off1, off2)))
+	vm.RcLimitsMax = max(vm.RcLimitsMax, value)
+	value = uint16(min(off0, min(off1, off2)))
+	vm.RcLimitsMin = min(vm.RcLimitsMin, value)
 	dstAddr, err := vm.getDstAddr(instruction)
 	if err != nil {
 		return fmt.Errorf("dst cell: %w", err)


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max