### PR TITLE
memory: bound segment growth to prevent makeslice panic on malformed program

### DIFF
--- a/pkg/vm/memory/memory.go
+++ b/pkg/vm/memory/memory.go
@@ -7,6 +7,13 @@ import (
 	f "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 )
 
+// maxSegmentSize bounds how large a single memory segment may grow. A memory access at an offset beyond
+// this returns an error instead of letting IncreaseSegmentSize call make() with an attacker-controlled
+// size, which panics ("makeslice: len out of range") and crashes the process on a malformed/malicious
+// program. The limit is intentionally generous (no legitimate execution approaches it) — maintainers may
+// tune it to the intended memory model.
+const maxSegmentSize = 1 << 34
+
 type BuiltinRunner interface {
 	fmt.Stringer
 	CheckWrite(segment *Segment, offset uint64, value *MemoryValue) error
@@ -98,6 +105,9 @@ func (segment *Segment) RealLen() uint64 {
 // different memory value
 func (segment *Segment) Write(offset uint64, value *MemoryValue) error {
 	if offset >= segment.RealLen() {
+		if offset >= maxSegmentSize {
+			return fmt.Errorf("memory offset %d exceeds max segment size %d", offset, maxSegmentSize)
+		}
 		segment.IncreaseSegmentSize(offset + 1)
 	}
 	if offset >= segment.Len() {
@@ -119,6 +129,9 @@ func (segment *Segment) Write(offset uint64, value *MemoryValue) error {
 // Reads a memory value from a specified offset at the segment
 func (segment *Segment) Read(offset uint64) (MemoryValue, error) {
 	if offset >= segment.RealLen() {
+		if offset >= maxSegmentSize {
+			return UnknownValue, fmt.Errorf("memory offset %d exceeds max segment size %d", offset, maxSegmentSize)
+		}
 		segment.IncreaseSegmentSize(offset + 1)
 	}
 

--- a/pkg/vm/memory/memory_test.go
+++ b/pkg/vm/memory/memory_test.go
@@ -291,3 +291,18 @@ func defaultSegment(anyData ...any) Segment {
 		BuiltinRunner: &NoBuiltin{},
 	}
 }
+
+// TestSegmentReadWriteHugeOffsetReturnsError verifies that a memory access at an absurd, program-controlled
+// offset returns an error instead of panicking in IncreaseSegmentSize's make() ("makeslice: len out of range"),
+// which previously crashed the process on a malformed program (e.g. the overflowing_dict fixture).
+func TestSegmentReadWriteHugeOffsetReturnsError(t *testing.T) {
+	huge := uint64(0x80000000000001) // > maxSegmentSize
+	seg := &Segment{Data: make([]MemoryValue, 0), BuiltinRunner: &NoBuiltin{}}
+	_, err := seg.Read(huge)
+	require.Error(t, err, "Read at a huge offset must error, not panic")
+
+	seg2 := &Segment{Data: make([]MemoryValue, 0), BuiltinRunner: &NoBuiltin{}}
+	v := EmptyMemoryValueAsFelt()
+	err = seg2.Write(huge, &v)
+	require.Error(t, err, "Write at a huge offset must error, not panic")
+}


### PR DESCRIPTION
## Problem

`Segment.Read`/`Write` grow a segment to fit an offset via `IncreaseSegmentSize(offset + 1)`, which does `make([]MemoryValue, newSize)` with an **unbounded, program-controlled** size. A program that reads or writes a huge memory offset makes the Go runtime panic with `makeslice: len out of range`, which **crashes the process** — there is no `recover()` in the VM/runner.

Repro (a program whose bytecode reads offset `0x80000000000001`):
```
panic: runtime error: makeslice: len out of range
  ...IncreaseSegmentSize (pkg/vm/memory/memory.go:160)
  ...Segment.Read (pkg/vm/memory/memory.go:122)
  ...RunStep -> RunUntilPc -> Run
```

## Fix

Reject an offset beyond a generous `maxSegmentSize` with a clean error in `Read`/`Write`, so a malformed program returns an error instead of crashing the host. The limit is intentionally generous (no legitimate execution approaches it) and commented as tunable to the intended memory model.

- `make([]MemoryValue, huge)` panic → graceful `error`.
- Adds `TestSegmentReadWriteHugeOffsetReturnsError`.
- No regression: `go test ./pkg/vm/memory/` passes; the repro program now returns `memory offset ... exceeds max segment size` instead of panicking.